### PR TITLE
Set NODE_TLS_REJECT_UNAUTHORIZED to "0" in coronerSetup when -k flag …

### DIFF
--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -316,7 +316,7 @@ function coronerSetupStart(coroner) {
 
 function coronerSetup(argv, config) {
   var pu;
-
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = (!!!argv.k) ? "1" : "0";
   try {
     pu = url.parse(argv._[1]);
   } catch (error) {


### PR DESCRIPTION
…is set.

Fixes #15