### PR TITLE
Fix rtn_type from instance to instance_retention

### DIFF
--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -5160,7 +5160,7 @@ function retentionSet(bpg, objects, argv, config) {
     rules[0].actions[0].subsets = ["physical"];
   }
 
-  if (rtn_type === "instance") {
+  if (rtn_type === "instance_retention") {
     if (argv._.length > 0) {
       return retentionUsage("Instances do not have names.");
     }


### PR DESCRIPTION
When setting `--type=instance` the variable `rtn_type` will receive the value of `"instance_retention"`, but this [if block](https://github.com/backtrace-labs/backtrace-morgue/blob/master/bin/morgue.js#L5163) is looking for `"instance"`.