### PR TITLE
Improve tenant URL computation logic

### DIFF
--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -835,14 +835,6 @@ function coronerLimit(argv, config) {
 
 function tenantURL(config, tn) {
   /*
-   * Get tenant separator. In Coronerd <1.46, this is always "." because
-   * it wasn't exposed via /api/config.
-   */
-  let tsep = config.config.tenant_separator;
-  if (!tsep)
-    tsep = '.';
-
-  /*
    * If there is no current universe, return the URL unchanged.
    * If this were just a split on ., it'd probably change the root domain
    * in this case.
@@ -851,8 +843,23 @@ function tenantURL(config, tn) {
     return config.endpoint;
 
   const uname = config.config.universe.name;
+  let pattern = uname;
+  let replacement = tn;
 
-  return config.endpoint.replace(uname + tsep, tn + tsep);
+  const tsep = config.config.tenant_separator;
+  if (tsep) {
+    /*
+     * Since the universe name and separator are known, go ahead and be
+     * stricter.
+     *
+     * For example, this would prevent localhost from becoming otherhost if
+     * moving from universe local to universe other.
+     */
+    pattern += tsep;
+    replacement += tsep;
+  }
+
+  return config.endpoint.replace(pattern, replacement);
 }
 
 function coronerInvite(argv, config) {

--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -838,8 +838,8 @@ function tenantURL(config, tn) {
    * Get tenant separator. In Coronerd <1.46, this is always "." because
    * it wasn't exposed via /api/config.
    */
-  var tsep = config.config.tenant_separator;
-  if (tsep === undefined)
+  let tsep = config.config.tenant_separator;
+  if (!tsep)
     tsep = '.';
 
   /*
@@ -847,10 +847,10 @@ function tenantURL(config, tn) {
    * If this were just a split on ., it'd probably change the root domain
    * in this case.
    */
-  if (config.config.universe === undefined || config.config.universe === null)
+  if (!config.config.universe)
     return config.endpoint;
 
-  var uname = config.config.universe.name;
+  const uname = config.config.universe.name;
 
   return config.endpoint.replace(uname + tsep, tn + tsep);
 }

--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -834,10 +834,25 @@ function coronerLimit(argv, config) {
 }
 
 function tenantURL(config, tn) {
-  var ix = config.endpoint.indexOf('.');
-  var s = [config.endpoint.substr(0, ix), config.endpoint.substr(ix)];
+  /*
+   * Get tenant separator. In Coronerd <1.46, this is always "." because
+   * it wasn't exposed via /api/config.
+   */
+  var tsep = config.config.tenant_separator;
+  if (tsep === undefined)
+    tsep = '.';
 
-  return 'https://' + tn + s[1];
+  /*
+   * If there is no current universe, return the URL unchanged.
+   * If this were just a split on ., it'd probably change the root domain
+   * in this case.
+   */
+  if (config.config.universe === undefined || config.config.universe === null)
+    return config.endpoint;
+
+  var uname = config.config.universe.name;
+
+  return config.endpoint.replace(uname + tsep, tn + tsep);
 }
 
 function coronerInvite(argv, config) {


### PR DESCRIPTION
This is to fix the case of users with customized tenant separators in multitenant configurations.  It additionally fixes other odd cases where the old algorithm of simply splitting on dot would likely break, for example IP addresses.

The new algorithm looks for the tenant separator in the configuration returned by Coronerd, defaulting to dot if it's not found, and is only willing to replace the universe name plus the separator.  For example if your separator is `.` and the universe is `my-universe` and the endpoint is `http://my-universe.backtrace.io`, attempts to access other tenants without changing users will use a call like `x.replace("my-universe.", "my-other-universe.")` to transform the URL.

Though initially introduced to solve the case of sending invites, this also fixes `morgue tenant list` in the common cases, which shows tenant URLs.

Testing performed was manual via modification of the hosts file against a local coronerd, using `morgue tenant list` to check the calls for sanity and sending e-mail invites to check the links those contain.