### PR TITLE
Parser for the quantize_uint virtual column

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,33 @@ syntax is `[-](<column>|<fold_term>)`.
 Multiple sort terms can be provided to break ties in case the previous
 referenced sort term has ties.
 
+#### Computed Views
+
+Coronerd offers support for a limited set of computed columns which can be
+used in selection and aggregation stages of a query.
+
+##### `--quantize-uint`
+
+Forms:
+
+```
+--quantize-uint output_column,input_column,size
+--quantize-uint output_column,input_column,size,offset
+```
+
+Computes `( column + offset ) / size - offset` using integer math.  Used for
+data alignment and rounding.
+
+Size and offset may be integers or time units: `3600` and `1h` are both valid.
+
+Typically size is a bin size and offset is a timezone offset from UTC.
+
+For example, errors by day in EDT:
+
+```
+morgue list project --count fingerprint --factor timestamp.edt.day --head timestamp.edt.day --quantize-uint timestamp.edt.day,timestamp,1d,-4h
+```
+
 #### Example
 
 Request all faults from application deployments owned by jdoe.


### PR DESCRIPTION
This is a parser for the new quantize uint virtual column, with documentation in `README.md` on how to use it.  I didn't go the long-hand route for the time being as we won't need that until the day arrives that we have dependencies between virtual columns.  usage is `--quantize-uint output,input,size,offset` where size and offset can be either an integer or a time unit such as `1h` or `-3h`.