### PR TITLE
Basic CLI for metrics-importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1160,3 +1160,64 @@ Possible roles:
 If a user has access through multiple sources (e.g. they belong to
 two teams and also have direct project membership) they will have
 the highest privileges afforded by any of those access routes.
+
+## Metrics Importing Functionality
+
+It is possible to use Morgue to configure importers for stability score.  THis
+requires Coronerd >= 1.48 and a deployed backtrace-metrics-importer.
+Usage:
+
+```
+morgue metrics-importer <command>...
+```
+
+### `source check-query`
+
+Determines if a query is valid by running it against a source as if it had been
+used with an importer and displays diagnostic information.  For example:
+
+```
+morgue metrics-importer source check-query --source my-source-uuid \
+--query 'select time, value from test where time >= $1 and time < $2'
+```
+
+### `importer create`
+
+Creates an importer.  Takes the following options:
+
+Option         | Description
+-------------- | --------------------------------------------------------------
+--source       | UUUID of the source to associate the importer with.
+--name         | The name of the importer to create.
+--start-at     |  The time to start scraping from in RFC3339 format.
+--metric       | The name of the metric to associate data with in Coronerd.
+--metric-group | The name of the metric group to associate data with in Coronerd.
+--delay        | The delay of the importer. Defaults to 60.
+
+For example:
+
+```
+morgue metrics-importer importer create \
+--source my-source-id \
+--name my-importer \
+--start-at 2020-08-05T00:00:00Z \
+--metric my-metric \
+--metric-group my-group \
+--quiery 'select time, value from test where time >= $ and time < $2' \
+--delay 120
+```
+
+Note that `--query` depends on the source type.  See the stability score
+documentation for details.
+
+### `logs`
+
+Displays logs.  Usage:
+
+```
+morgue metrics-importer logs --source-id my-source-id
+morgue metrics-importer logs --importer-id my-importer-id
+```
+
+You can pass `--limit` to limit the number of returned messages.
+By default `--limit` is 100.

--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -33,6 +33,7 @@ const zlib      = require('zlib');
 const symbold = require('../lib/symbold.js');
 const createCsvWriter = require('csv-writer').createObjectCsvWriter;
 const Slack = require('slack-node');
+const metricsImporterCli = require('../lib/metricsImporter/cli.js');
 
 var levenshtein;
 
@@ -255,6 +256,7 @@ var commands = {
   user: coronerUser,
   merge: coronerMerge,
   unmerge: coronerUnmerge,
+  "metrics-importer": metricsImporterCmd,
 };
 
 process.stdout.on('error', function(){process.exit(0);});
@@ -7415,6 +7417,14 @@ function coronerRetention(argv, config) {
   }
 
   retentionUsage("Invalid retention subcommand '" + subcmd + "'.");
+}
+
+async function metricsImporterCmd(argv, config) {
+  abortIfNotLoggedIn(config);
+  const coroner = coronerClientArgv(config, argv);
+  const cli = await metricsImporterCli.metricsImporterCliFromCoroner(coroner);
+  argv._.shift();
+  await cli.routeMethod(argv);
 }
 
 function main() {

--- a/lib/coroner.js
+++ b/lib/coroner.js
@@ -2,6 +2,7 @@
 
 const qs = require('querystring');
 const url = require('url');
+const urlJoin = require('url-join');
 const path = require('path');
 var request = require('request');
 var fs = require('fs')
@@ -593,6 +594,36 @@ CoronerClient.prototype.delete_objects = function(universe, project, objects, pa
 
   this.post("/api/delete", {}, p, null, callback);
 };
+
+/*
+ * Find a service from its name.
+ */
+CoronerClient.prototype.find_service = async function (name) {
+  /*
+   * Config comes from current.json and may be stale. get a new one
+   * to find the most recent location of the service.
+   */
+  const config = JSON.parse(await this.promise("get", "/api/config", null));
+  const serviceEntry = config.services.filter(x => x.name === name)[0];
+  if (!serviceEntry) {
+    throw new Error(`No ${ name } service is configured`);
+  }
+  const endpoint = serviceEntry.endpoint;
+  if (!endpoint) {
+    throw new Error(`Service ${ name } doesn't have an endpoint`);
+  }
+  /*
+   * Frontend gets to assume that relative urls will work because it's
+   * in a browser and pointed at the same domain. We can't, because this is
+   * node.
+   */
+  const relative = endpoint.match(/https?:\/\//) === null;
+  if (relative) {
+    return urlJoin(this.endpoint, endpoint);
+  } else {
+    return endpoint;
+  }
+}
 
 function extend(o, src) {
   for (var key in src) o[key] = src[key];

--- a/lib/metricsImporter/cli.js
+++ b/lib/metricsImporter/cli.js
@@ -1,0 +1,219 @@
+const client = require('./client');
+
+function validateOne(option, value) {
+  if (!value) {
+    console.error(`--${ option } is required`);
+    return false;
+  }
+  if (Array.isArray(value)) {
+    console.error(`--${ option } must have exactly one value`);
+    return false;
+  }
+  return true;
+}
+
+function validateZeroOrOne(option, value) {
+  if (Array.isArray(value)) {
+    console.error(`--${ option } must have at most one value`);
+    return false;
+  }
+  return true;
+}
+
+class MetricsImporterCli {
+  constructor(client) {
+    this.client = client;
+  }
+
+  async routeMethod(args) {
+    const routes = {
+      'importer': {
+        create: (args) => this.importerCreate(args),
+      },
+      source: {
+        'check-query': (args) => this.sourceCheckQuery(args),
+      },
+      'logs': (args) => this.logs(args),
+    };
+
+    let route = routes;
+    let next;
+    while (typeof route === 'object') {
+      next = args._[0];
+      args._.shift();
+      if (!next) {
+        route = null;
+        break;
+      }
+      route = route[next];
+    }
+
+    if (!route) {
+      console.error("Unrecognized command. See metrics-importer help for usage");
+      return;
+    }
+    await route(args);
+  }
+
+  help() {
+    console.warn(`
+    usage: morgue metrics-import [<entity>] <command> <options>
+    
+    Command may be one of the following:
+    
+    source check-query: Run a test query against a given source.
+    importer create: create an importer.
+    logs: Get logs by source id or importer id.
+    
+    For full documentation, please see:
+    https://github.com/backtrace-labs/backtrace-morgue
+    `);
+  }
+
+  async logs(args) {
+    const project = args._[0];
+    const sourceId = args['source'];
+    const importerId = args['importer'];
+    let limit = 100;
+
+    if (!project) {
+      console.log("Project is required");
+      return;
+    }
+    if (!validateZeroOrOne('source', sourceId) ||
+      !validateZeroOrOne('importer', importerId)) {
+      return;
+    }
+    if (!sourceId && !importerId) {
+      console.error("Specify either --source or --importer, not both");
+      return;
+    }
+
+    if ('limit' in args) {
+      limit = Number.parseInt(args.limit);
+      if (Number.isNaN(limit) || limit <= 0) {
+        console.error("--limit must be a positive integer");
+        return;
+      }
+    }
+
+    const response = await this.client.logs({ project, sourceId,
+      importerId, limit });
+
+    if (response.messages.length === 0) {
+      console.log("No logs");
+      return;
+    }
+
+    /*
+     * The service gives us messages most recent first, but we want to display
+     * most recent last.
+     */
+    const sorted = response.messages.reverse();
+    for (let m of sorted) {
+      const time = (new Date(m.time * 1000)).toISOString();
+      let msg;
+      if (importerId) {
+        msg = `${ time } ${ m.message }`;
+      } else {
+        msg = `${ time } importer=${ m.sourceId } ${ m.message }`;
+      }
+      msg = `${ m.level.padEnd(9) }${ msg }`;
+      console.log(msg);
+    }
+  }
+
+  async importerCreate(args) {
+    const project = args._[0];
+    const sourceId = args["source"];
+    const query = args.query;
+    const startAtUnparsed = args["start-at"];
+    const delay = args.delay;
+    const metric = args.metric;
+    const metricGroup = args['metric-group'];
+    const name = args.name;
+
+    if (!project) {
+      console.error("Project is required");
+      return;
+    }
+
+    if (!validateOne("source", sourceId) ||
+      !validateOne("name", name) ||
+      !validateOne("metric", metric) ||
+      !validateOne("metric-group", metricGroup) ||
+      !validateZeroOrOne("delay", delay) ||
+      !validateZeroOrOne("start-at", startAtUnparsed)) {
+        return;
+    }
+
+    /* By default, scrape the last day. */
+    let startAt = new Date(Date.now() - 24 * 60 * 1000);
+    if (startAtUnparsed) {
+      startAt = new Date(startAtUnparsed);
+      if (Number.isNaN(startAt.getTime())) {
+        console.error("Unable to parse --start-at");
+        return;
+      }
+    }
+
+    const params = {
+      project,
+      sourceId,
+      name,
+      metric,
+      metricGroup,
+      query,
+      startAt: Math.floor(startAt.getTime() / 1000),
+      delay: delay !== undefined ? delay : 60,
+    };
+
+    const resp = await this.client.createImporter(params);
+    console.log(`Importer id ${ resp.id }`);
+  }
+
+  async sourceCheckQuery(args) {
+    const project = args._[0];
+    const sourceId = args['source'];
+    const query = args.query;
+
+    if (!project) {
+      console.error("Project is required");
+      return;
+    }
+    
+    if (!validateOne("source", sourceId) ||
+      !validateOne("query", query)) {
+      return;
+    }
+
+    const resp = await this.client.checkSource({ project, sourceId, query });
+    if (resp.errors.length) {
+      console.log("Errors:");
+      resp.errors.map(i => console.log(i));
+      console.log("");
+    }
+    if (resp.warnings.length) {
+      console.log("Warnings:");
+      resp.warnings.map(i => console.log(i));
+      console.log("");
+    }
+    if (resp.success) {
+      console.log(
+        "This query can be used as a valid importer query for this source");
+    } else {
+      console.log(`If used to create an importer, this query will be unable to
+complete scrapes successfully.`);
+    }
+  }
+}
+
+async function metricsImporterCliFromCoroner(coroner) {
+  const c = await client.metricsImporterClientFromCoroner(coroner);
+  return new MetricsImporterCli(c);
+}
+
+module.exports = {
+  MetricsImporterCli,
+  metricsImporterCliFromCoroner
+};

--- a/lib/metricsImporter/client.js
+++ b/lib/metricsImporter/client.js
@@ -1,0 +1,106 @@
+const request = require('request');
+const urlJoin = require('url-join');
+
+class MetricsImporterClient {
+  constructor(url, coronerLocation, coronerToken) {
+    this.url = url;
+    this.coronerLocation = coronerLocation;
+    this.coronerToken = coronerToken;
+  }
+
+  /*
+   * Make a request to metrics-importer.
+   *
+   * @param method: lower-case HTTP method
+   * @param path: Relative URL to hit.
+   * @param body: Optional body. Will be sent as JSON.
+   * @param qs: Optional URL parameters.
+   *
+   * Returns a promise that resolves to the JSON-decoded response.
+   */
+  request(method, path, body = null, qs = {}) {
+    return new Promise((resolve, reject) => {
+      const url = urlJoin(this.url, path);
+      let options = {
+        url,
+        method: method.toUpperCase(),
+        headers: {
+          "X-Coroner-Location": this.coronerLocation,
+          "X-Coroner-Token": this.coronerToken,
+        },
+        qs,
+        json: true,
+      };
+      if (body) {
+        options.body = body;
+      }
+      request(options, (err, resp, body) => {
+        if (err) {
+          reject(err);
+        } else {
+          if (resp.statusCode >= 400) {
+            if (body && body.error && body.error.message) {
+              reject(`HTTP status ${resp.statusCode}: ${body.error.message}`);
+            } else {
+              reject(`HTTP status ${ resp.statusCode }`);
+            }
+          } else {
+            resolve(body);
+          }
+        }
+      });
+    });
+  }
+
+  async checkSource({ project, sourceId, query }) {
+    return await this.request("get",
+      `/projects/${ project }/sources/${ sourceId}/check`,
+      /* No body. */
+      null,
+      { query },
+    );
+  }
+
+  async createImporter({ project, sourceId, name, query, metric, metricGroup,
+    startAt, delay, enabled = true }) {
+    const body = {
+      project,
+      sourceId,
+      name,
+      startAt,
+      query,
+      metric,
+      metricGroup,
+      delay,
+      enabled,
+    };
+    const url = `/projects/${ project }/importers`;
+    return await this.request("post", url, body);
+  }
+
+  async logs({ project, sourceId = null, importerId = null, limit = 1000 }) {
+    let params = { limit };
+    if (sourceId) {
+      params.sourceId = sourceId;
+    }
+    if (importerId) {
+      params.importerId = importerId;
+    }
+    const url = `/projects/${ project }/logs`;
+    return await this.request('get', url, null, params);
+  }
+}
+
+/*
+ * Make a MetricsImporterClient from a CoronerClient.
+ */
+async function metricsImporterClientFromCoroner(coroner) {
+  const serviceUrl = await coroner.find_service("metrics-importer");
+  return new MetricsImporterClient(serviceUrl,
+    coroner.endpoint, coroner.config.token);
+}
+
+module.exports = {
+  MetricsImporterClient,
+  metricsImporterClientFromCoroner
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -5044,6 +5044,11 @@
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
       "dev": true
     },
+    "url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="
+    },
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "streamsink": "^1.2.0",
     "sync-request": "^5.0.0",
     "table": "^4.0.1",
-    "time-ago": "^0.2.1"
+    "time-ago": "^0.2.1",
+    "url-join": "^4.0.1"
   },
   "optionalDependencies": {
     "levenshtein-sse": "^1.1.0"


### PR DESCRIPTION
This contains the following:

- Support for metrics-importer commands:
  - `metrics-importer logs` to get logs
  - `metrics-importer source check-query` to test a query
  - `metrics-importer importer create` to create importers.
- The beginnings of a properly abstracted HTTP client for the service.
- Support for catching errors from Morgue commands that use async/await directly that doesn't trigger Node's deprecation warning.

This is intended to be a minimal cut for CI and troubleshooting purposes with further improvements based on user demand.  Notable missing functionality includes the ability to list, modify, or delete resources.

I wrote this with an eye to being abstractable, reusable, and a pattern we may wish to follow with future microservices that need Morgue interfaces.  Though that abstraction hasn't happened, the intent is that it would be relatively easy to pull out routing and validation helpers and to follow this directory structure in future.  Notably, it is possible to use `lib/metricsImporter/client.js` as a library to control the service programmatically.  Though I wouldn't call that API stable at this time, the intent is that it won't change.