### PR TITLE
Add case-insensitive as an optional 4th argument to filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ The currently supported operations are `equal`, `regular-expression`,
 `inverse-regular-expression`, `at-least`, `greater-than`, `at-most`,
 `less-than`, `contains`, `not-contains`, `is-set`, and `is-not-set`.
 
+When using Coronerd 1.49 or greater, `contains`, `not-contains`,
+`regular-expression`, and `inverse-regular-expression` accept an optional 4th
+argument `case-insensitive` to enable case-insensitive filtering.
+
 #### Pagination
 
 Pagination is handled with two flags

--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -4429,6 +4429,26 @@ function parseSortTerm(term) {
   return {name: name, ordering: ordering};
 }
 
+/*
+ * Assumes that we start at the 4th argument, and returns a filter object.
+ */
+function parseFilterFlags(filter) {
+  if (filter.length < 4) {
+    return {};
+  }
+
+  let flags = {};
+  const known_flags = new Set([ 'case_insensitive' ]);
+  for (const f of filter.slice(3)) {
+    const transformed = f.replace("-", "_");
+    if (!known_flags.has(transformed)) {
+      errx(`Unknown filter flag ${ f }`);
+    }
+    flags[transformed] = true;
+  }
+  return flags;
+}
+
 function argvQuery(argv) {
   var query = {};
   var d_age = null;
@@ -4473,6 +4493,9 @@ function argvQuery(argv) {
         expr = [r[1]];
       else if (r.length == 3)
         expr = [r[1], r[2]];
+      else if (r.length == 4)
+        expr = [r[1], r[2], parseFilterFlags(r)];
+
 
       query.filter[0][r[0]].push(expr);
     }


### PR DESCRIPTION
This translates into { "case_insensitive": true } as a flags object.

Works in Coronerd 1.49+.

We could be more strict about our verification: you could for example do `--filter bla,greater-than,5,case-insensitive` but just letting it work here means no modification to Morgue until we want case-insensitive on a single-argument filter, or until we want to add a new flag.