### PR TITLE
Add support for the BPG side of stability score and improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1168,9 +1168,62 @@ If a user has access through multiple sources (e.g. they belong to
 two teams and also have direct project membership) they will have
 the highest privileges afforded by any of those access routes.
 
-## Metrics Importing Functionality
+## Stability Score and Storing Metrics Data
 
-It is possible to use Morgue to configure importers for stability score.  THis
+Morgue offers the ability to configure metrics for importing metrics data with
+`metrics-importer` or custom API integrations.  This can be used from CI to
+provision new metrics against a metric group and begin shipping data.  At the
+moment, Morgue assumes setup and most common operations on entities for
+metrics importing are carried out through the frontend and only offers the
+subset of functionality necessary for automation from CI.
+
+Generally, the typical flow occurs in two stages.  First:
+
+```
+morgue stability create-metric --project myproj --metric-group stability \
+--name metric-v1.2 --attribute version,1.2
+```
+
+Which creates the metric in Coronerd against a pre-existing metric group, then:
+
+```
+morgue metrics-importer importer create \
+--source my-source-id \
+--name my-importer \
+--start-at 2020-08-05T00:00:00Z \
+--metric my-metric \
+--metric-group my-group \
+--quiery 'select time, value from test where time >= $ and time < $2' \
+--delay 120
+```
+
+Which will ship data from the associated `metrics-importer` instance.
+
+### Provisioning a coronerd-side metric
+
+Usage:
+
+```
+morgue stability create-metric --universe universe \
+-- project project \
+--metric-group my-group \
+--name my-metric \
+--attribute version,2.0 \
+--attribute country,US \
+...
+```
+
+This will provision a metric on the Coronerd side that can be fed via
+`metrics-importer` or via a custom API integration against Coronerd's
+timeseries submission endpoints.
+
+Attribute values are of the form `--attribute name,value`.
+An attribute value must be specified for every non-defaulted attribute 
+on the group.
+
+### Controlling `metrics-importer`
+
+It is possible to use Morgue to configure importers for stability score.  This
 requires Coronerd >= 1.48 and a deployed backtrace-metrics-importer.
 Usage:
 
@@ -1178,7 +1231,7 @@ Usage:
 morgue metrics-importer <command>...
 ```
 
-### `source check-query`
+#### `source check-query`
 
 Determines if a query is valid by running it against a source as if it had been
 used with an importer and displays diagnostic information.  For example:
@@ -1188,7 +1241,7 @@ morgue metrics-importer source check-query --source my-source-uuid \
 --query 'select time, value from test where time >= $1 and time < $2'
 ```
 
-### `importer create`
+#### `importer create`
 
 Creates an importer.  Takes the following options:
 
@@ -1217,7 +1270,7 @@ morgue metrics-importer importer create \
 Note that `--query` depends on the source type.  See the stability score
 documentation for details.
 
-### `logs`
+#### `logs`
 
 Displays logs.  Usage:
 


### PR DESCRIPTION
We now document how to integrate morgue into your CI process for stability
score, and offer a `morgue stability create-metric` command, for example:

```
./bin/morgue.js stability create-metric \
--project cts \
--metric-group stability \
--name test-metric \
--attribute version,1.0
```

Which simply gives:

```
Metric created
```

This is the BPG half of the stability flow, separated into two commands to
preserve the ability to allow API integrations to occur. This doesn't implement
anything beyond the minimum necessary for CI.  In addition to adding the above
command, the readme contains a walkthrough of how to use these commands together
on new releases.  The frontend is currently required for more complex
operations.

Note that this PR and #47 have a lot in common.  I'm hoping to find some time to address the lack of abstraction in future PRs: we're now at 2 instances of the rule of 3, and there's almost certainly other places that could benefit.  I've chosen not to do that here in order to keep the reviews separate and to reduce code churn on something that requires entirely manual testing.