### PR TITLE
When using morgue get on json reports, save as plaintext json.

### DIFF
--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -2872,7 +2872,7 @@ function coronerGet(argv, config) {
       var fname = getFname(hr, out.path, argv.outdir, objects.length, oid, params.resource);
       success++;
       if (fname) {
-        if (hr.headers["content-encoding"] === "gzip" && params.resource === "json.gz") {
+        if (hr.headers["content-encoding"] === "gzip" && (params.resource === "json.gz" || params.resource === "txt.gz")) {
           let unzippedBodyData;
           try {
             unzippedBodyData = zlib.gunzipSync(hr.bodyData);

--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -2872,6 +2872,16 @@ function coronerGet(argv, config) {
       var fname = getFname(hr, out.path, argv.outdir, objects.length, oid, params.resource);
       success++;
       if (fname) {
+        if (hr.headers["content-encoding"] === "gzip" && params.resource === "json.gz") {
+          let unzippedBodyData;
+          try {
+            unzippedBodyData = zlib.gunzipSync(hr.bodyData);
+          }
+          catch (error) {
+            console.log('Unable to decompress json data');
+          }
+          if (unzippedBodyData) hr.bodyData = unzippedBodyData;
+        }
         fs.writeFileSync(fname, hr.bodyData);
         console.log(sprintf('Wrote %ld bytes to %s', hr.bodyData.length, fname).success);
       } else {


### PR DESCRIPTION
morgue get, when used on json.gz, will sometimes get a gzip compressed page in response.  In these cases, decompress the json and save it as plaintext.