### PR TITLE
0x prepend to _tx value converts from hex to deci on filter

### DIFF
--- a/lib/cli/query.js
+++ b/lib/cli/query.js
@@ -124,6 +124,13 @@ function argvQuery(argv) {
         errx('Filter must be of form <column>,<operation>[,<value>].');
       }
 
+      if (r[0] == "_tx" && r.length == 3 && typeof r[2] === "string") {
+        var rr = r[2].split("x");
+        if (rr.length === 2) {
+          r = [r[0], r[1], parseInt(rr[1], 16)];
+        }
+      }
+
       if (!query.filter[0][r[0]])
         query.filter[0][r[0]] = [];
 


### PR DESCRIPTION
When filtering on `_tx`, allow a user to enter a hex value prepending with `0x`.  Otherwise is assumed enter in base 10.