### PR TITLE
split off various parts of bin/morgue.js to modules in preparation for future reuse in alerts

### DIFF
--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -34,7 +34,9 @@ const symbold = require('../lib/symbold.js');
 const createCsvWriter = require('csv-writer').createObjectCsvWriter;
 const Slack = require('slack-node');
 const metricsImporterCli = require('../lib/metricsImporter/cli.js');
+
 const timeCli = require('../lib/cli/time');
+const { err, errx } = require('../lib/cli/errors');
 
 var flamegraph = path.join(__dirname, "..", "assets", "flamegraph.pl");
 
@@ -84,29 +86,6 @@ function oidToString(oid) {
 
 function oidFromString(oid) {
   return parseInt(oid, 16);
-}
-
-function err(msg) {
-  if (msg) {
-    var m = msg.toString();
-    if (m.slice(0, 5) !== "Error")
-      m = "Error: " + m;
-    console.log(m.error);
-  } else {
-    console.log("Unknown error occured.".error);
-  }
-  return false;
-}
-
-function errx(errobj, opts) {
-  if (typeof errobj === 'object' && errobj.message) {
-    if (typeof opts === 'object' && opts.debug)
-      console.log("err = ", errobj);
-    err(errobj.message);
-  } else {
-    err(errobj);
-  }
-  process.exit(1);
 }
 
 /* Standardized success/failure callbacks. */

--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -36,6 +36,7 @@ const Slack = require('slack-node');
 const metricsImporterCli = require('../lib/metricsImporter/cli.js');
 
 const timeCli = require('../lib/cli/time');
+const queryCli = require('../lib/cli/query');
 const { err, errx } = require('../lib/cli/errors');
 
 var flamegraph = path.join(__dirname, "..", "assets", "flamegraph.pl");
@@ -743,7 +744,7 @@ function coronerCI(argv, config) {
   let attribute = argv.run;
 
   /* Get a summary of issues found by tool for a given run. */
-  let query = argvQuery(argv);
+  let query = queryCli.argvQuery(argv);
   let q_v = query.query;
   q_v.filter[0][attribute] = [ [ "equal", value ] ];
   q_v.filter[0]['fingerprint;issues;state'] = [ [ "regular-expression", "open|progress" ] ];
@@ -907,7 +908,7 @@ function coronerCts(argv, config) {
   let attribute = argv._[2];
   let value = argv._[3];
 
-  let query = argvQuery(argv);
+  let query = queryCli.argvQuery(argv);
   let q_v = query.query;
   q_v.filter[0][attribute] = [ [ "equal", value ] ];
   q_v.filter[0]["fingerprint;issues;tags"] = [ [ "not-contains", value ] ];
@@ -2568,7 +2569,7 @@ function coronerReport(argv, config) {
     var histogram = argv.histogram;
     var widgets = {};
     var limit = argv.limit;
-    var aq = argvQuery(argv);
+    var aq = queryCli.argvQuery(argv);
     var rcpt = '';
     var include_users = false;
 
@@ -4468,295 +4469,6 @@ function coronerScrubber(argv, config) {
   }
 }
 
-function argvQuantizeUint(argv) {
-  let q = argv["quantize-uint"];
-
-  if (!q)
-    return [];
-
-  if (!Array.isArray(q))
-    q = [ q ];
-
-  return q.map(a => {
-    let segs = a.split(",");
-
-    if (segs.length < 3) {
-      errx("Quantize column definition is of the form output_name,backing_column,size,[offset]");
-    }
-
-    let [name, backing, size, offset] = segs;
-    if (offset === undefined || offset === null) {
-      offset = "0";
-    }
-
-    size = timeCli.parseTimeInt(size);
-    offset = timeCli.parseTimeInt(offset);
-
-    return {
-      name: name,
-      type: "quantize_uint",
-      quantize_uint: {
-        backing_column: backing,
-        size: size,
-        offset: offset,
-      }
-    };
-  });
-}
-
-function argvVcols(args) {
-  return argvQuantizeUint(args);
-}
-
-/* Some subcommands don't make sense with folds etc. */
-function argvQueryFilterOnly(argv) {
-  if (argv.select || argv.filter || argv.fingerprint || argv.age || argv.time) {
-    /* Object must be returned for query to be chainable. */
-    if (!argv.select && !argv.template) {
-      argv.select = 'object';
-    }
-    return argvQuery(argv);
-  }
-  return null;
-}
-
-function parseSortTerm(term) {
-  var ordering = "ascending";
-  var name = term;
-
-  if (term[0] === "-") {
-    ordering = "descending";
-    name = term.slice(1);
-  }
-
-  return {name: name, ordering: ordering};
-}
-
-/*
- * Assumes that we start at the 4th argument, and returns a filter object.
- */
-function parseFilterFlags(filter) {
-  if (filter.length < 4) {
-    return {};
-  }
-
-  let flags = {};
-  const known_flags = new Set([ 'case_insensitive' ]);
-  for (const f of filter.slice(3)) {
-    const transformed = f.replace("-", "_");
-    if (!known_flags.has(transformed)) {
-      errx(`Unknown filter flag ${ f }`);
-    }
-    flags[transformed] = true;
-  }
-  return flags;
-}
-
-function argvQuery(argv) {
-  var query = {};
-  var d_age = null;
-
-  if (argv['raw-query']) {
-    return { query: JSON.parse(argv['raw-query']) };
-  }
-
-  if (argv.reverse)
-    reverse = -1;
-
-  if (argv.template)
-    query.template = argv.template;
-
-  if (argv.limit)
-    query.limit = argv.limit;
-
-  if (argv.offset)
-    query.offset = argv.offset;
-
-  query.filter = [{}];
-  if (argv.filter) {
-    var i;
-
-    if (Array.isArray(argv.filter) === false)
-      argv.filter = [argv.filter];
-
-    for (i = 0; i < argv.filter.length; i++) {
-      var r = argv.filter[i];
-      var expr = [];
-
-      r = r.split(',');
-      if (r.length < 2) {
-        errx('Filter must be of form <column>,<operation>[,<value>].');
-      }
-
-      if (!query.filter[0][r[0]])
-        query.filter[0][r[0]] = [];
-
-      /* Some operators don't require an argument. */
-      if (r.length == 2)
-        expr = [r[1]];
-      else if (r.length == 3)
-        expr = [r[1], r[2]];
-      else if (r.length == 4)
-        expr = [r[1], r[2], parseFilterFlags(r)];
-
-
-      query.filter[0][r[0]].push(expr);
-    }
-  }
-
-  if (argv.sort) {
-    if (Array.isArray(argv.sort) === false)
-      argv.sort  = [argv.sort];
-
-    query.order = argv.sort.map(parseSortTerm);
-  }
-
-  if (!query.filter[0].timestamp)
-    query.filter[0].timestamp = [];
-
-  if (argv.time) {
-    if (query.filter[0].timestamp && query.filter[0].timestamp.length > 0)
-      errx('Cannot mix --time and timestamp filters');
-
-    var tm = chrono.parse(argv.time);
-    var ts_attr = 'timestamp';
-    var ts_s, ts_e;
-
-    if (argv.debug)
-      console.log('tm = ', JSON.stringify(tm, null, 4));
-
-    if (tm.length === 0)
-      errx('invalid time specifier "' + argv.time + '"');
-
-    if (tm.length > 1) {
-      if (tm.length === 2) {
-        /* See whether it parsed as two starts and no ends. */
-        if (tm[0].start && tm[1].start && !tm[0].end && !tm[1].end) {
-          ts_s = tm[0].start.date();
-          ts_e = tm[1].start.date();
-        }
-      }
-      if (!ts_s)
-        errx('only a single date or range is permitted.'.error);
-    } else {
-      if (!tm[0].start)
-        errx('date specification lacks start date'.error);
-
-      if (!tm[0].end)
-        errx('date specification lacks end date'.error);
-
-      ts_s = tm[0].start.date();
-      ts_e = tm[0].end.date();
-    }
-
-    /* Treat zero start time as greater than zero to exclude unset values. */
-    ts_s = parseInt(ts_s / 1000);
-    if (ts_s === 0)
-      ts_s = 1;
-    ts_e = parseInt(ts_e / 1000);
-
-    /* If user specifies a timestamp attribute, use it. */
-    if (argv["timestamp-attribute"] && argv["timestamp-attribute"].length > 0)
-      ts_attr = argv["timestamp-attribute"];
-
-    query.filter[0][ts_attr] = [
-      [ 'at-least', ts_s ],
-      [ 'less-than', ts_e ]
-    ];
-
-    d_age = null;
-  }
-
-  if (argv.factor) {
-    query.group = [ argv.factor ];
-  }
-
-  query.virtual_columns = argvVcols(argv);
-
-  if (argv.template === 'select') {
-  } else if (argv.select) {
-    if (!query.select)
-      query.select = [];
-
-    if (Array.isArray(argv.select) === true) {
-      for (let i = 0; i < argv.select.length; i++) {
-        query.select.push(argv.select[i]);
-      }
-    } else {
-      query.select = [ argv.select ];
-    }
-  } else if (argv.table === 'objects') {
-    query.fold = {
-      'timestamp' : [['range'], ['bin']]
-    };
-  }
-
-  /*
-   * The fingerprint argument is a convenience function for filtering by
-   * a group.
-   */
-  if (argv.fingerprint) {
-    var length, op, ar;
-
-    if (Array.isArray(argv.fingerprint) === true) {
-      errx('Only one fingerprint argument can be specified.');
-    }
-
-    length = String(argv.fingerprint).length;
-    if (length === 64) {
-      op = 'equal';
-      ar = argv.fingerprint;
-    } else {
-      op = 'regular-expression';
-      ar = '^' + argv.fingerprint;
-    }
-
-    if (!query.filter[0].fingerprint)
-      query.filter[0].fingerprint = [];
-    query.filter[0].fingerprint.push([op, ar]);
-  }
-
-  if (argv.age) {
-    if (query.filter[0].timestamp && query.filter[0].timestamp.length > 0)
-      errx('Cannot mix --age and timestamp filters');
-
-    d_age = argv.age;
-  } else if (!query.filter[0].timestamp || query.filter[0].timestamp.length == 0) {
-    d_age = '1M';
-  }
-
-  if (d_age) {
-    var now = Date.now();
-    var target = parseInt(now / 1000) - timeCli.timespecToSeconds(d_age);
-    var oldest = Math.floor(target);
-
-    query.filter[0].timestamp = [
-      [ 'at-least', oldest ]
-    ];
-
-    range_start = oldest;
-    range_stop = Math.floor(now / 1000);
-
-    if (query.fold && query.fold.timestamp) {
-      var ft = query.fold.timestamp;
-      var i;
-
-      for (i = 0; i < ft.length; i++) {
-        if (ft[i][0] === 'bin') {
-          ft[i] = ft[i].concat([32, range_start, range_stop]);
-        }
-      }
-    }
-  }
-
-  if (argv.table === 'objects') {
-    if (!query.filter[0].timestamp || query.filter[0].timestamp.length === 0)
-      query.filter[0].timestamp.push([ 'greater-than', 0 ]);
-  }
-
-  return { query: query, age: d_age };
-}
-
 function bpgPost(bpg, request, callback) {
   var json, msg, response;
 
@@ -5200,7 +4912,7 @@ function coronerFlamegraph(argv, config) {
 
   p = coronerParams(argv, config);
 
-  var aq = argvQuery(argv);
+  var aq = queryCli.argvQuery(argv);
   query = aq.query;
   var d_age = aq.age;
   var data = '';
@@ -5367,7 +5079,7 @@ function coronerSet(argv, config) {
     argv.table = 'objects';
   }
 
-  var aq = argvQuery(argv);
+  var aq = queryCli.argvQuery(argv);
   query = aq.query;
 
   delete(query.fold);
@@ -5533,7 +5245,7 @@ async function coronerCleanAsync(argv, config) {
     argv.table = 'objects';
   }
 
-  var aq = argvQuery(argv);
+  var aq = queryCli.argvQuery(argv);
   query = aq.query;
   var d_age = aq.age;
 
@@ -5601,7 +5313,7 @@ function coronerList(argv, config) {
     argv.table = 'objects';
   }
 
-  var aq = argvQuery(argv);
+  var aq = queryCli.argvQuery(argv);
   query = aq.query;
   var d_age = aq.age;
 
@@ -6613,7 +6325,7 @@ function coronerDelete(argv, config) {
 
   abortIfNotLoggedIn(config);
 
-  aq = argvQueryFilterOnly(argv);
+  aq = queryCli.argvQueryFilterOnly(argv);
   coroner = coronerClientArgv(config, argv);
   p = coronerParams(argv, config);
   o = argv._.slice(2);
@@ -6704,7 +6416,7 @@ function coronerReprocess(argv, config) {
   if (argv.last)
     params.last = oidToString(argv.last);
 
-  aq = argvQueryFilterOnly(argv);
+  aq = queryCli.argvQueryFilterOnly(argv);
   coroner = coronerClientArgv(config, argv);
 
   /* Check for a query parameter to be sent. */

--- a/lib/cli/errors.js
+++ b/lib/cli/errors.js
@@ -1,0 +1,29 @@
+
+/*
+ * Error handling helpers.
+ */
+
+ function err(msg) {
+  if (msg) {
+    var m = msg.toString();
+    if (m.slice(0, 5) !== "Error")
+      m = "Error: " + m;
+    console.log(m.error);
+  } else {
+    console.log("Unknown error occured.".error);
+  }
+  return false;
+}
+
+function errx(errobj, opts) {
+  if (typeof errobj === 'object' && errobj.message) {
+    if (typeof opts === 'object' && opts.debug)
+      console.log("err = ", errobj);
+    err(errobj.message);
+  } else {
+    err(errobj);
+  }
+  process.exit(1);
+}
+
+module.exports = { err, errx };

--- a/lib/cli/query.js
+++ b/lib/cli/query.js
@@ -1,0 +1,299 @@
+/*
+ * Helper functions for building queries from CLI args.
+ */
+const timeCli = require('./time');
+const { err, errx } = require('./errors');
+
+function argvQuantizeUint(argv) {
+  let q = argv["quantize-uint"];
+
+  if (!q)
+    return [];
+
+  if (!Array.isArray(q))
+    q = [ q ];
+
+  return q.map(a => {
+    let segs = a.split(",");
+
+    if (segs.length < 3) {
+      errx("Quantize column definition is of the form output_name,backing_column,size,[offset]");
+    }
+
+    let [name, backing, size, offset] = segs;
+    if (offset === undefined || offset === null) {
+      offset = "0";
+    }
+
+    size = timeCli.parseTimeInt(size);
+    offset = timeCli.parseTimeInt(offset);
+
+    return {
+      name: name,
+      type: "quantize_uint",
+      quantize_uint: {
+        backing_column: backing,
+        size: size,
+        offset: offset,
+      }
+    };
+  });
+}
+
+function argvVcols(args) {
+  return argvQuantizeUint(args);
+}
+
+/* Some subcommands don't make sense with folds etc. */
+function argvQueryFilterOnly(argv) {
+  if (argv.select || argv.filter || argv.fingerprint || argv.age || argv.time) {
+    /* Object must be returned for query to be chainable. */
+    if (!argv.select && !argv.template) {
+      argv.select = 'object';
+    }
+    return argvQuery(argv);
+  }
+  return null;
+}
+
+function parseSortTerm(term) {
+  var ordering = "ascending";
+  var name = term;
+
+  if (term[0] === "-") {
+    ordering = "descending";
+    name = term.slice(1);
+  }
+
+  return {name: name, ordering: ordering};
+}
+
+/*
+ * Assumes that we start at the 4th argument, and returns a filter object.
+ */
+function parseFilterFlags(filter) {
+  if (filter.length < 4) {
+    return {};
+  }
+
+  let flags = {};
+  const known_flags = new Set([ 'case_insensitive' ]);
+  for (const f of filter.slice(3)) {
+    const transformed = f.replace("-", "_");
+    if (!known_flags.has(transformed)) {
+      errx(`Unknown filter flag ${ f }`);
+    }
+    flags[transformed] = true;
+  }
+  return flags;
+}
+
+function argvQuery(argv) {
+  var query = {};
+  var d_age = null;
+
+  if (argv['raw-query']) {
+    return { query: JSON.parse(argv['raw-query']) };
+  }
+
+  if (argv.reverse)
+    reverse = -1;
+
+  if (argv.template)
+    query.template = argv.template;
+
+  if (argv.limit)
+    query.limit = argv.limit;
+
+  if (argv.offset)
+    query.offset = argv.offset;
+
+  query.filter = [{}];
+  if (argv.filter) {
+    var i;
+
+    if (Array.isArray(argv.filter) === false)
+      argv.filter = [argv.filter];
+
+    for (i = 0; i < argv.filter.length; i++) {
+      var r = argv.filter[i];
+      var expr = [];
+
+      r = r.split(',');
+      if (r.length < 2) {
+        errx('Filter must be of form <column>,<operation>[,<value>].');
+      }
+
+      if (!query.filter[0][r[0]])
+        query.filter[0][r[0]] = [];
+
+      /* Some operators don't require an argument. */
+      if (r.length == 2)
+        expr = [r[1]];
+      else if (r.length == 3)
+        expr = [r[1], r[2]];
+      else if (r.length == 4)
+        expr = [r[1], r[2], parseFilterFlags(r)];
+
+
+      query.filter[0][r[0]].push(expr);
+    }
+  }
+
+  if (argv.sort) {
+    if (Array.isArray(argv.sort) === false)
+      argv.sort  = [argv.sort];
+
+    query.order = argv.sort.map(parseSortTerm);
+  }
+
+  if (!query.filter[0].timestamp)
+    query.filter[0].timestamp = [];
+
+  if (argv.time) {
+    if (query.filter[0].timestamp && query.filter[0].timestamp.length > 0)
+      errx('Cannot mix --time and timestamp filters');
+
+    var tm = chrono.parse(argv.time);
+    var ts_attr = 'timestamp';
+    var ts_s, ts_e;
+
+    if (argv.debug)
+      console.log('tm = ', JSON.stringify(tm, null, 4));
+
+    if (tm.length === 0)
+      errx('invalid time specifier "' + argv.time + '"');
+
+    if (tm.length > 1) {
+      if (tm.length === 2) {
+        /* See whether it parsed as two starts and no ends. */
+        if (tm[0].start && tm[1].start && !tm[0].end && !tm[1].end) {
+          ts_s = tm[0].start.date();
+          ts_e = tm[1].start.date();
+        }
+      }
+      if (!ts_s)
+        errx('only a single date or range is permitted.'.error);
+    } else {
+      if (!tm[0].start)
+        errx('date specification lacks start date'.error);
+
+      if (!tm[0].end)
+        errx('date specification lacks end date'.error);
+
+      ts_s = tm[0].start.date();
+      ts_e = tm[0].end.date();
+    }
+
+    /* Treat zero start time as greater than zero to exclude unset values. */
+    ts_s = parseInt(ts_s / 1000);
+    if (ts_s === 0)
+      ts_s = 1;
+    ts_e = parseInt(ts_e / 1000);
+
+    /* If user specifies a timestamp attribute, use it. */
+    if (argv["timestamp-attribute"] && argv["timestamp-attribute"].length > 0)
+      ts_attr = argv["timestamp-attribute"];
+
+    query.filter[0][ts_attr] = [
+      [ 'at-least', ts_s ],
+      [ 'less-than', ts_e ]
+    ];
+
+    d_age = null;
+  }
+
+  if (argv.factor) {
+    query.group = [ argv.factor ];
+  }
+
+  query.virtual_columns = argvVcols(argv);
+
+  if (argv.template === 'select') {
+  } else if (argv.select) {
+    if (!query.select)
+      query.select = [];
+
+    if (Array.isArray(argv.select) === true) {
+      for (let i = 0; i < argv.select.length; i++) {
+        query.select.push(argv.select[i]);
+      }
+    } else {
+      query.select = [ argv.select ];
+    }
+  } else if (argv.table === 'objects') {
+    query.fold = {
+      'timestamp' : [['range'], ['bin']]
+    };
+  }
+
+  /*
+   * The fingerprint argument is a convenience function for filtering by
+   * a group.
+   */
+  if (argv.fingerprint) {
+    var length, op, ar;
+
+    if (Array.isArray(argv.fingerprint) === true) {
+      errx('Only one fingerprint argument can be specified.');
+    }
+
+    length = String(argv.fingerprint).length;
+    if (length === 64) {
+      op = 'equal';
+      ar = argv.fingerprint;
+    } else {
+      op = 'regular-expression';
+      ar = '^' + argv.fingerprint;
+    }
+
+    if (!query.filter[0].fingerprint)
+      query.filter[0].fingerprint = [];
+    query.filter[0].fingerprint.push([op, ar]);
+  }
+
+  if (argv.age) {
+    if (query.filter[0].timestamp && query.filter[0].timestamp.length > 0)
+      errx('Cannot mix --age and timestamp filters');
+
+    d_age = argv.age;
+  } else if (!query.filter[0].timestamp || query.filter[0].timestamp.length == 0) {
+    d_age = '1M';
+  }
+
+  if (d_age) {
+    var now = Date.now();
+    var target = parseInt(now / 1000) - timeCli.timespecToSeconds(d_age);
+    var oldest = Math.floor(target);
+
+    query.filter[0].timestamp = [
+      [ 'at-least', oldest ]
+    ];
+
+    range_start = oldest;
+    range_stop = Math.floor(now / 1000);
+
+    if (query.fold && query.fold.timestamp) {
+      var ft = query.fold.timestamp;
+      var i;
+
+      for (i = 0; i < ft.length; i++) {
+        if (ft[i][0] === 'bin') {
+          ft[i] = ft[i].concat([32, range_start, range_stop]);
+        }
+      }
+    }
+  }
+
+  if (argv.table === 'objects') {
+    if (!query.filter[0].timestamp || query.filter[0].timestamp.length === 0)
+      query.filter[0].timestamp.push([ 'greater-than', 0 ]);
+  }
+
+  return { query: query, age: d_age };
+}
+
+module.exports = {
+  argvQuery,
+  argvQueryFilterOnly,
+};

--- a/lib/cli/time.js
+++ b/lib/cli/time.js
@@ -1,0 +1,81 @@
+/*
+ * Date/time helpers for translating to/from the CLI args format.
+ *
+ * We support y/M/d/h/m/s units, in decreasing order (m is minutes,
+ * M is months).
+ */
+
+/*
+ * Takes a time specifier and returns the number of seconds.
+ */
+function timespecToSeconds(age_val) {
+  var unit = {
+    'y' : 3600 * 24 * 365,
+    'M' : 3600 * 24 * 30,
+    'w' : 3600 * 24 * 7,
+    'd' : 3600 * 24,
+    'h' : 3600,
+    'm' : 60,
+    's' : 1,
+  };
+  var age, pre, age_string, iu;
+
+  if (typeof age_val === 'number')
+    return age_val;
+
+  age = parseFloat(age_val);
+  pre = String(age);
+  age_string = String(age_val);
+  iu = age_string.substring(pre.length, age_string.length);
+  if (iu.length === 0)
+    iu = 's';
+  if (!unit[iu])
+    throw new Error("Unknown interval unit '" + iu + "'");
+  return parseInt(age * unit[iu]);
+}
+
+/*
+ * Takes a value in seconds and returns a time specifier.
+ */
+function secondsToTimespec(age_val) {
+  var age = parseInt(age_val);
+  var ts = {};
+
+  /* Handle special zero case. */
+  if (age === 0)
+    return "0s";
+
+  ts['y'] = Math.floor(age / (3600 * 24 * 365));
+  age -= (ts['y'] * 3600 * 24 * 365);
+  ts['M'] = Math.floor(age / (3600 * 24 * 30));
+  age -= (ts['M'] * 3600 * 24 * 30);
+  ts['w'] = Math.floor(age / (3600 * 24 * 7));
+  age -= (ts['w'] * 3600 * 24 * 7);
+  ts['d'] = Math.floor(age / (3600 * 24));
+  age -= (ts['d'] * 3600 * 24);
+  ts['h'] = Math.floor(age / 3600);
+  age -= ts['h'] * 3600;
+  ts['m'] = Math.floor(age / 60);
+  age -= ts['m'] * 60;
+  ts['s'] = age;
+
+  return Object.keys(ts).reduce(function(str, key) {
+    if (ts[key] !== 0)
+      str += ts[key] + key;
+    return str;
+  }, "");
+}
+
+function parseTimeInt(x) {
+  let i = parseInt(x);
+  if (i === NaN || String(i) !== x) {
+    i = timespecToSeconds(x);
+  }
+  return i;
+}
+
+module.exports = {
+  parseTimeInt,
+  timespecToSeconds,
+  secondsToTimespec
+};


### PR DESCRIPTION
This splits off the following to separate modules:

- time parsers
- error helper functions
- query builders

I've submitted it as one pr because GitHub is bad about dependent diff stacks.  Testing is manual.  I hit all the eason ones, but we'll want some real-world coverage.  The best way to review this is probably to find the occurances of the moved functions in the current codebase and make sure they all match up with their imports; there's surprisingly few of them.

I need this in for alerts, which needs to reuse all the query parsing logic.  I might also have to move more, but we'll see on that.

This was a mechanical change.  Things like var are remnants of the old code.