### PR TITLE
Alerts CLI and general refactoring

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,14 @@
+module.exports = {
+    "env": {
+        "browser": false,
+        "commonjs": true,
+        "es2021": true,
+        "node": true
+    },
+    "extends": "eslint:recommended",
+    "parserOptions": {
+        "ecmaVersion": 12
+    },
+    "rules": {
+    }
+};

--- a/lib/alerts/cli.js
+++ b/lib/alerts/cli.js
@@ -1,0 +1,351 @@
+const router = require('../cli/router');
+const options = require('../cli/options');
+const time = require('../cli/time');
+const { errx } = require('../cli/errors');
+const queryCli = require('../cli/query');
+
+const client = require('./client');
+
+const HELP_MESSAGE = `
+USAGE:
+
+morgue alerts target [create | list | get | update | delete] <args>
+morgue alerts alert [create | list | get | update | delete] <args>
+
+See the Morgue README for option documentation.
+`;
+class AlertsCli {
+  constructor(client, universe, project) {
+    this.client = client;
+    this.client.setDefaultQs({ universe, project });
+  }
+
+  async routeMethod(args) {
+    const routes = {
+      target: {
+        get: this.getTarget.bind(this),
+        list: this.listTargets.bind(this),
+        create: this.createTarget.bind(this),
+        delete: this.deleteTarget.bind(this),
+        update: this.updateTarget.bind(this),
+      },
+      alert: {
+        get: this.getAlert.bind(this),
+        list: this.listAlerts.bind(this),
+        create: this.createAlert.bind(this),
+        update: this.updateAlert.bind(this),
+        delete: this.deleteAlert.bind(this),
+      }
+    };
+
+    router.route(routes, HELP_MESSAGE, args);
+  }
+
+  async targetIdFromName(name) {
+    for await (const t of this.client.listTargets()) {
+      if (t.name == name) {
+        return t.id;
+      }
+    }
+    errx(`Target ${name} not found`);
+  }
+
+  async targetIdFromArgs(argv) {
+    let id = options.convertAtMostOne("id", argv.id);
+    let name = options.convertAtMostOne("name", argv.name);
+    if (!id && !name) {
+      errx("One of --id or --name is required");
+    }
+    if (!id) {
+      id = await this.targetIdFromName(name);
+    }
+    return id;
+  }
+
+  printTarget(target) {
+    console.log(`${target.id}`);
+    console.log(`  name=${target.name} workflow=${target.workflow1.workflow_name}`);
+  }
+
+  async getTarget(argv) {
+    const id = await this.targetIdFromArgs(argv);
+    const target = await this.client.getTarget(id);
+    this.printTarget(target);
+  }
+
+  async listTargets() {
+    for await (const t of this.client.listTargets()) {
+      this.printTarget(t);
+    }
+  }
+
+  async createTarget(argv) {
+    const name = options.convertOne("name", argv.name);
+    const workflowName =
+      options.convertOne("workflow-name", argv["workflow-name"]);
+    const res = await this.client.createTarget({
+      name,
+      target_type: "workflow1",
+      workflow1: {
+        workflow_name: workflowName,
+      }
+    });
+    console.log(`Created target ${res.id}`);
+  }
+
+  async deleteTarget(argv) {
+    const id = await this.targetIdFromArgs(argv);
+    await this.client.deleteTarget(id);
+    console.log(`Deleted target ${id}`);
+  }
+
+  async updateTarget(argv) {
+    const id = await this.targetIdFromArgs(argv);
+    const newName = options.convertAtMostOne("rename", argv.rename);
+    const workflowName =
+      options.convertAtMostOne("workflow-name", argv["workflow-name"]);
+    let target = await this.client.getTarget(id);
+    if (newName) {
+      target.name = newName;
+    }
+    if (workflowName) {
+      target.workflow1.workflow_name = workflowName;
+    }
+    await this.client.updateTarget(id, target);
+    console.log(`Target ${id} updated`);
+  }
+
+  async alertIdFromName(name) {
+    for await (const a of this.client.listAlerts()) {
+      if (a.name == name) {
+        return a.id;
+      }
+    }
+    errx(`Alert ${name} not found`);
+  }
+
+  async alertIdFromArgs(argv) {
+    let id = options.convertAtMostOne("id", argv.id);
+    let name = options.convertAtMostOne("name", argv.name);
+    if (!id && !name) {
+      errx("One of --id or --name is required");
+    }
+    if (!id) {
+      id = await this.alertIdFromName(name);
+    }
+    return id;
+  }
+
+  /*
+   * Generate a possibly partial alert specification, minus the query, which
+   * is handled separately.
+   *
+   */
+  async generateAlertSpec(argv, isCreate) {
+    const convertOne = isCreate ? options.convertOne : options.convertAtMostOne;
+    const partial = {
+      name: convertOne("name", argv.name),
+      /* This is always optional, defaults true below if in create. */
+      enabled: options.convertAtMostOne("enabled", argv.enabled),
+      query_period: convertOne("query-period", argv['query-period']),
+      min_notification_interval: convertOne("min-notification-interval",
+        argv['min-notification-interval']),
+      /* Also always optional; defaults to 0 if in create. */
+      mute_until: options.convertAtMostOne("mute-until", argv['mute-until']),
+      triggers: options.convertMany("trigger", argv.trigger, true),
+    };
+
+    if (partial.enabled === undefined || partial.enabled === null) {
+      if (isCreate) {
+        partial.enabled = true;
+      }
+    } else {
+      partial.enabled = options.convertBool("enabled", partial.enabled);
+    }
+    if (partial.mute_until === undefined || partial.mute_until === null) {
+      if (isCreate) {
+        partial.mute_until = 0;
+      }
+    }
+
+    /*
+     * targets are always optional, even on create.
+     */
+    let targetIds = options.convertMany("target-id", argv['target-id'], true);
+    const targetNames = options.convertMany("target-name",
+      argv['target-name'], true);
+
+    if (targetIds) {
+      partial.targets = targetIds;
+    }
+
+    if (targetNames) {
+      partial.targets = partial.targets || [];
+      for (const t of targetNames) {
+        partial.targets.push(await this.targetIdFromName(t));
+      }
+    }
+
+    if (partial.query_period) {
+      partial.query_period = time.timespecToSeconds(partial.query_period);
+    }
+
+    if (partial.min_notification_interval) {
+      partial.min_notification_interval =
+        time.timespecToSeconds(partial.min_notification_interval);
+    }
+
+    /*
+     * the format of a trigger is column,index,comparison,warning,critical.
+     */
+    if (partial.triggers) {
+      let parsedTriggers = [];
+      for (const t of partial.triggers) {
+        const split = t.split(",");
+        if (split.length != 5) {
+          errx("The format of a trigger is column,aggregation_index,comparison,warning,critical");
+        }
+        const [column, index_str, comparison, warningStr, criticalStr] = split;
+        const index = Number.parseInt(index_str);
+        if (Number.isNaN(index)) {
+          errx("Trigger indices must be integers");
+        }
+        if (comparison != "le" && comparison != "ge") {
+          errx("Valid trigger comparisons are le or ge");
+        }
+        const warning = Number.parseFloat(warningStr);
+        if (Number.isNaN(warning)) {
+          errx("Trigger warning is not a valid number");
+        }
+        const critical = Number.parseFloat(criticalStr);
+        if (Number.isNaN(critical)) {
+          errx("Trigger critical threshold is not a number");
+        }
+
+        parsedTriggers.push({
+          aggregation: {
+            column,
+            index,
+          },
+          comparison_operator: comparison,
+          warning_threshold: warning,
+          critical_threshold: critical,
+        });
+      }
+
+      partial.triggers = parsedTriggers;
+    }
+
+    return partial;
+  }
+
+  async createAlert(argv) {
+    const spec = await this.generateAlertSpec(argv, true);
+
+    const query = queryCli.argvQuery(argv, /*implicitTimestampOps=*/false,
+      /*doFolds=*/true).query;
+    if (query.select) {
+      errx("Alerts only work on aggregation queryes");
+    }
+
+    const queryStr = JSON.stringify(query);
+    spec.query = queryStr;
+
+    let res = await this.client.createAlert(spec);
+    console.log(`Created alert ${res.id}`);
+  }
+
+  async updateAlert(argv) {
+    let unfilteredSpec = this.generateAlertSpec(argv, false);
+
+    /*
+     * Filter out anything which wasn't set.
+     */
+    const spec = {};
+    for (const [k, v] of unfilteredSpec) {
+      if (v === null || v === undefined) {
+        continue;
+      }
+      spec[k] = v;
+    }
+
+    /*
+     * get rid of name, if set.
+     */
+    delete spec.name;
+    const newName = options.convertAtMostOne("rename", argv.rename);
+    if (newName) {
+      spec.name = newName;
+    }
+
+    /*
+     * because argvQuery is happy to generate queries from empty args, require
+     * the user to be explicit.
+     */
+    if (argv['replace-query']) {
+      const query = queryCli.argvQuery(argv, /*implicitTimestampOps=*/false,
+        /*doFolds=*/true).query;
+      if (query.select) {
+        errx("Alerts only work with aggregation queries");
+      }
+      updated.query = JSON.stringify(query);
+    }
+
+    if (argv['clear-targets']) {
+      updated.targets = [];
+    }
+
+    const id = this.alertIdFromArgv(argv);
+    const alert  = await this.client.getAlert(id);
+    const updated = { ...alert, ...spec };
+    await this.client.updateAlert(id, updated);
+    console.log(`Updated alert ${id}`);
+  }
+
+  printAlert(a) {
+    const period = time.secondsToTimespec(a.query_period);
+    console.log(`${a.id}`);
+    /* Note: we don't have a way to pretty print CRDB queries. */
+    console.log(`  name=${a.name} period=${period}`);
+  }
+
+  async listAlerts() {
+    for await (const a of this.client.listAlerts()) {
+      this.printAlert(a);
+    }
+  }
+
+  async getAlert(argv) {
+    const id = await this.alertIdFromArgs(argv);
+    const alert = await this.client.getAlert(id);
+    this.printAlert(alert);
+  }
+
+  async deleteAlert(argv) {
+    const id = await this.alertIdFromArgs(argv);
+    await this.client.deleteAlert(id);
+    console.log(`Deleted alert ${id}`);
+  }
+}
+
+async function alertsCliFromCoroner(coroner, argv, config) {
+  let universe = options.convertAtMostOne("universe", argv.universe);
+  const project = options.convertOne("project", argv.project);
+  /*
+   * Currently the Rust service infrastructure doesn't support inferring
+   * universe, so do it on our end if we can.
+   */
+  if (!universe && config.config.universe) {
+    universe = config.config.universe.name;
+  }
+  if (!universe) {
+    errx("Unable to infer universe from config. Please provide --universe to select");
+  }
+  const c = await client.alertsClientFromCoroner(coroner);
+  return new AlertsCli(c, universe, project);
+}
+
+module.exports = {
+  AlertsCli,
+  alertsCliFromCoroner,
+};

--- a/lib/alerts/cli.js
+++ b/lib/alerts/cli.js
@@ -38,7 +38,7 @@ class AlertsCli {
       }
     };
 
-    router.route(routes, HELP_MESSAGE, args);
+    await router.route(routes, HELP_MESSAGE, args);
   }
 
   async targetIdFromName(name) {

--- a/lib/alerts/client.js
+++ b/lib/alerts/client.js
@@ -1,8 +1,8 @@
-const serviceClient = require('../serviceClient');
+const baseServiceClient = require('../baseServiceClient');
 
-class AlertsClient extends serviceClient.ServiceClient {
-  constructor(url, coronerLocation, coronerToken) {
-    super(url, coronerLocation, coronerToken);
+class AlertsClient extends baseServiceClient.BaseServiceClient {
+  constructor(url, coronerLocation, coronerToken, insecure) {
+    super(url, coronerLocation, coronerToken, insecure);
   }
 
   async createTarget(body) {
@@ -51,7 +51,7 @@ class AlertsClient extends serviceClient.ServiceClient {
 async function alertsClientFromCoroner(coroner) {
   const serviceUrl = await coroner.find_service("alerts");
   return new AlertsClient(serviceUrl,
-    coroner.endpoint, coroner.config.token);
+    coroner.endpoint, coroner.config.token, coroner.insecure);
 }
 
 module.exports = {

--- a/lib/alerts/client.js
+++ b/lib/alerts/client.js
@@ -1,0 +1,60 @@
+const serviceClient = require('../serviceClient');
+
+class AlertsClient extends serviceClient.ServiceClient {
+  constructor(url, coronerLocation, coronerToken) {
+    super(url, coronerLocation, coronerToken);
+  }
+
+  async createTarget(body) {
+    return await this.request({ method: "POST", path: "/targets", body });
+  }
+
+  async getTarget(id) {
+    return await this.request({ method: "GET", path: `/targets/${id}` });
+  }
+
+  /* Returns an async iterator. */
+  listTargets() {
+    return this.tokenPager({ method: "GET", path: "/targets" });
+  }
+
+  async updateTarget(id, body) {
+    return await this.request({ method: "put", path: `/targets/${id}`, body });
+  }
+
+  async deleteTarget(id) {
+    return await this.request({ method: "DELETE", path: `/targets/${id}` });
+  }
+
+  async createAlert(body) {
+    return await this.request({ method: "POST", path: "/alerts", body });
+  }
+
+  async getALert(id) {
+    return this.request({ method: "GET", path: `/alerts/${id}` });
+  }
+
+  /* Returns an async iterator. */
+  listAlerts() {
+    return this.tokenPager({ method: "GET", path: "/alerts" });
+  }
+
+  async updateAlert(id, body) {
+    return await this.request({ method: "PUT", path: `/alerts/${id}`, body });
+  }
+
+  async deleteAlert(id) {
+    return this.request({ method: "DELETE", path: `/alerts/${id}` });
+  }
+}
+
+async function alertsClientFromCoroner(coroner) {
+  const serviceUrl = await coroner.find_service("alerts");
+  return new AlertsClient(serviceUrl,
+    coroner.endpoint, coroner.config.token);
+}
+
+module.exports = {
+  AlertsClient,
+  alertsClientFromCoroner,
+};

--- a/lib/baseServiceClient.js
+++ b/lib/baseServiceClient.js
@@ -76,7 +76,7 @@ class BaseServiceClient {
         },
         qs: actualQs,
         json: true,
-        strictSSL: !this.secure,
+        strictSSL: !this.insecure,
       };
       if (body) {
         options.body = body;

--- a/lib/baseServiceClient.js
+++ b/lib/baseServiceClient.js
@@ -1,24 +1,36 @@
 /*
- * provides a service client that can be subclassed by specific
- * implementations, as well as other helpers useful when writing services.
+ * provides a base that can be subclassed by specific
+ * service clients, as well as other helpers useful when writing services.
  *
  *This is intended for the CLI use case, so errors aren't as
  * helpful as they could be.  If we want to separate this into a library,
  * we'll need to clean it up some.
  *
- * To use, subclass this class, pass the parameters up to the constructor,
- * and then use this.request to make requests. The class will handle
- * authenticating and manual url location.
+ * To write a service client with this interface,  subclass this class, pass the
+ * parameters up to the constructor, and then use this.request to make requests.
+ * The class will handle authenticating and specification of the
+ * `X-Coronerd-Location` header, and offers
+ * functions to aid in pagination which we will extend on a case-by-case basis
+ * as we need them.
  */
 const request = require('request');
 const urlJoin = require('url-join');
 
-class ServiceClient {
-  constructor(url, coronerLocation, coronerToken) {
+class BaseServiceClient {
+  /*
+   * @param url: The base URL of the service.
+   * @param coronerLocation: the URL to the Coronerd instance.
+   * !@param coronerToken: The token to use to authenticate with Coronerd and
+   *        the service.
+   * @param insecure: set to true if the user passed `-k` or otherwise
+   *        requested that SSL certs not be verified.
+   */
+  constructor(url, coronerLocation, coronerToken, insecure=false) {
     this.url = url;
     this.coronerLocation = coronerLocation;
     this.coronerToken = coronerToken;
     this.defaultQs = {};
+    this.insecure = insecure;
   }
 
   /*
@@ -28,7 +40,6 @@ class ServiceClient {
   setDefaultQs(qs) {
     this.defaultQs = qs;
   }
-
 
   /*
    * Make a request to the service.
@@ -41,7 +52,10 @@ class ServiceClient {
    * Returns a promise that resolves to the JSON-decoded response.
    *
    * For convenience when parsing CLI options, filters out any querystring
-   * parameters which are set to undefined or null.
+   * parameters which are set to undefined or null.  This allows one to pass
+   * optional CLI args directly through to the service without having to go
+   * through the trouble of making sure they aren't included, since minimist is
+   * too minimal to provide defaults and other validation.
    */
   request({ method, path, body = null, qs = {} }) {
     let actualQs = {};
@@ -62,6 +76,7 @@ class ServiceClient {
         },
         qs: actualQs,
         json: true,
+        strictSSL: !this.secure,
       };
       if (body) {
         options.body = body;
@@ -87,10 +102,13 @@ class ServiceClient {
   /*
    * Implements pagination against services using the page_token scheme:
    * { "values": [ ... ], "next_page_token": "token" }
+   *
+   * This scheme is used by Rust services which have additional requirements
+   * that make limit-offset pagination unsuitable.
    */
   async *tokenPager({ method, path, body=null, qs = {} }) {
     /*
-     * Clone this so that if we passed somethingthe caller will still use, we
+     * Clone this so that if we passed something the caller will still use, we
      * won't corrupt their state.
      */
     qs = { ... qs };
@@ -111,5 +129,5 @@ class ServiceClient {
 }
 
 module.exports = {
-  ServiceClient
+  BaseServiceClient
 };

--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -1,0 +1,108 @@
+/*
+ * validation and conversion helpers for CLI args.
+ *
+ * The convention is that option is the human-friendly option name (which is
+ * hard to determine programatically) and value the value, i.e.:
+ *
+ * validateZeroOrOne("--alert-name", argv['alert-name'])
+ */
+const { err, errx } = require('./errors');
+
+/*
+ * validates that the specified option was specified exactly once.
+ */
+function validateOne(option, value) {
+  if (value === null || value === undefined) {
+    err(`--${ option } is required`);
+    return false;
+  }
+  if (Array.isArray(value)) {
+    err(`--${ option } must have exactly one value`);
+    return false;
+  }
+  return true;
+}
+
+/*
+ * validates that the specified option was specified at most once.
+ */
+function validateAtMostOne(option, value) {
+  if (Array.isArray(value)) {
+    err(`--${ option } must have at most one value`);
+    return false;
+  }
+  return true;
+}
+
+/*
+ * Given an option name and value, convert to a single value.
+ * Will exit the process with an informative error if the conversion fails.
+ */
+function convertOne(option, value) {
+  if (!validateOne(option, value)) {
+    process.exit(1);
+  }
+  return value;
+}
+
+function convertAtMostOne(option, value) {
+    if (!validateAtMostOne(option, value)) {
+    process.exit(1);
+  }
+  return value;
+}
+
+/*
+ * Will convert an option to an array. Assumes that this array
+ * will have at least one item by default. To change this, specify
+ * the third optional argument as false.
+ */
+function convertMany(option, value, allowEmpty = false) {
+  if (allowEmpty && !value) {
+    return [];
+  }
+
+  if (!value) {
+    errx(`--${option} must be specified at least once`);
+  }
+
+  if (!Array.isArray(value)) {
+    return [ value ];
+  }
+
+  return value;
+}
+
+const TRUTH_STRINGS = new Set([ 'yes', 'true', 'on', '1' ]);
+const FALSE_STRINGS = new Set([ 'no', 'false', 'off', '0' ]);
+
+function convertBool(name, value, defaultValue = undefined) {
+  let v;
+  if (defaultValue != undefined) {
+    v = convertAtMostOne(name, value);
+  } else {
+    v = convertOne(name, value);
+  }
+  if (v == undefined) {
+    return defaultValue;
+  }
+  if (typeof v === 'boolean') {
+    return v;
+  }
+  if (TRUTH_STRINGS.has(v)) {
+    return true;
+  }
+  if (FALSE_STRINGS.has(v)) {
+    return false;
+  }
+  errx(`--${name}: unrecognized boolean option ${v}`);
+}
+
+module.exports = {
+  validateOne,
+  validateAtMostOne,
+  convertOne,
+  convertAtMostOne,
+  convertMany,
+  convertBool,
+};

--- a/lib/cli/query.js
+++ b/lib/cli/query.js
@@ -88,7 +88,7 @@ function parseFilterFlags(filter) {
   return flags;
 }
 
-function argvQuery(argv) {
+function argvQueryPrefold(argv, implicitTimestampOps) {
   var query = {};
   var d_age = null;
 
@@ -154,7 +154,7 @@ function argvQuery(argv) {
     query.order = argv.sort.map(parseSortTerm);
   }
 
-  if (!query.filter[0].timestamp)
+  if (!query.filter[0].timestamp && implicitTimestampOps)
     query.filter[0].timestamp = [];
 
   if (argv.time) {
@@ -228,7 +228,7 @@ function argvQuery(argv) {
     } else {
       query.select = [ argv.select ];
     }
-  } else if (argv.table === 'objects') {
+  } else if (argv.table === 'objects' && implicitTimestampOps) {
     query.fold = {
       'timestamp' : [['range'], ['bin']]
     };
@@ -268,7 +268,7 @@ function argvQuery(argv) {
     d_age = '1M';
   }
 
-  if (d_age) {
+  if (d_age && implicitTimestampOps) {
     var now = Date.now();
     var target = parseInt(now / 1000) - timeCli.timespecToSeconds(d_age);
     var oldest = Math.floor(target);
@@ -280,7 +280,7 @@ function argvQuery(argv) {
     range_start = oldest;
     range_stop = Math.floor(now / 1000);
 
-    if (query.fold && query.fold.timestamp) {
+    if (query.fold && query.fold.timestamp && implicitTimestampOps) {
       var ft = query.fold.timestamp;
       var i;
 
@@ -293,12 +293,91 @@ function argvQuery(argv) {
   }
 
   if (argv.table === 'objects') {
-    if (!query.filter[0].timestamp || query.filter[0].timestamp.length === 0)
+    if (!query.filter[0].timestamp || query.filter[0].timestamp.length === 0 &&
+      implicitTimestampOps)
       query.filter[0].timestamp.push([ 'greater-than', 0 ]);
   }
 
   return { query: query, age: d_age };
 }
+
+/*
+ * Generate a query from argv.
+ *
+ * if implicitTimestampOps is false, don't add anything to do with timestamp.
+ * this is used by alerts among other things to allow for the user to enter
+ * queries without having to know the JSON syntax.
+ */
+function argvQuery(argv, implicitTimeOps=false, doFolds=false) {
+  const { query, age } = argvQueryPrefold(argv, implicitTimeOps);
+
+  if (!doFolds) {
+    return { query, age };
+  }
+
+  /*
+   * This was originally lifted from morgue.js and not refactored because it's
+   * fragile.
+   */
+  function fold(query, attribute, label) {
+    var argv, i;
+
+    if (!query.fold)
+      query.fold = {};
+
+    if (Array.isArray(attribute) === false) {
+      attribute = [ attribute ];
+    }
+
+    for (i = 0; i < attribute.length; i++) {
+      var modifiers, j;
+
+      modifiers = attribute[i].split(',');
+      argv = modifiers[0];
+      modifiers.shift();
+
+      for (j = 0; j < modifiers.length; j++) {
+        modifiers[j] = parseInt(modifiers[j]);
+        if (isNaN(modifiers[j]) === true) {
+          errx('Modifiers must be integers.');
+        }
+      }
+
+      if (!query.fold[argv])
+        query.fold[argv] = [];
+
+      query.fold[argv].push([label].concat(modifiers));
+    }
+  }
+
+  const folds = [
+    [argv.last, 'last'],
+    [argv.first, 'first'],
+    [argv.tail, 'tail'],
+    [argv.head, 'head'],
+    [argv.object, 'object'],
+    [argv.histogram, 'histogram'],
+    [argv.distribution, 'distribution'],
+    [argv.unique, 'unique'],
+    [argv.mean, 'mean'],
+    [argv.sum, 'sum'],
+    [argv.quantize, 'bin'],
+    [argv.bin, 'bin'],
+    [argv.range, 'range'],
+    [argv.count, 'count'],
+  ];
+
+  /* Apply requested folds to query */
+  folds.forEach(function(attr_op) {
+    const [attr, op] = attr_op;
+    if (attr)
+      fold(query, attr, op);
+  });
+
+  return { query, age };
+}
+
+
 
 module.exports = {
   argvQuery,

--- a/lib/cli/router.js
+++ b/lib/cli/router.js
@@ -1,0 +1,45 @@
+/*
+ * A simple subcommand router. Routes commands to subcommands, eating arguments
+ * off the front.
+ *
+ * We dont' do anything involved here, i.e. no command specific help. This just
+ * takes a (possibly nested) object of functions, figures out where the command
+ * is going, and sends it there.
+ */
+
+/*
+ * Commands is:
+ * {
+ *   command: function,
+ *   command2: {
+ *     subcommand: function,
+ *   }
+ * }
+ *
+ * Displays usage on failure.
+ */
+async function route(commands, usage, args) {
+  let route = commands;
+  let next;
+
+  while (typeof route == 'object') {
+    next = args._[0];
+    args._.shift();
+    if (!next) {
+      route = null;
+      break;
+    }
+    route = route[next];
+  }
+
+  if (!route) {
+    console.error(usage);
+    process.exit(1);
+  }
+
+  await route(args);
+}
+
+module.exports = {
+  route
+};

--- a/lib/serviceClient.js
+++ b/lib/serviceClient.js
@@ -1,0 +1,115 @@
+/*
+ * provides a service client that can be subclassed by specific
+ * implementations, as well as other helpers useful when writing services.
+ *
+ *This is intended for the CLI use case, so errors aren't as
+ * helpful as they could be.  If we want to separate this into a library,
+ * we'll need to clean it up some.
+ *
+ * To use, subclass this class, pass the parameters up to the constructor,
+ * and then use this.request to make requests. The class will handle
+ * authenticating and manual url location.
+ */
+const request = require('request');
+const urlJoin = require('url-join');
+
+class ServiceClient {
+  constructor(url, coronerLocation, coronerToken) {
+    this.url = url;
+    this.coronerLocation = coronerLocation;
+    this.coronerToken = coronerToken;
+    this.defaultQs = {};
+  }
+
+  /*
+   * Set a set of default querystring parameters. This is used primarily to
+   * inject universe/project.
+   */
+  setDefaultQs(qs) {
+    this.defaultQs = qs;
+  }
+
+
+  /*
+   * Make a request to the service.
+   *
+   * @param method: lower-case HTTP method
+   * @param path: Relative URL to hit.
+   * @param body: Optional body. Will be sent as JSON.
+   * @param qs: Optional URL parameters.
+   *
+   * Returns a promise that resolves to the JSON-decoded response.
+   *
+   * For convenience when parsing CLI options, filters out any querystring
+   * parameters which are set to undefined or null.
+   */
+  request({ method, path, body = null, qs = {} }) {
+    let actualQs = {};
+    for (const [k, v] of Object.entries({ ...qs, ... this.defaultQs })) {
+      if (v === undefined || v == null) {
+        continue;
+      }
+      actualQs[k] = v;
+    }
+    return new Promise((resolve, reject) => {
+      const url = urlJoin(this.url, path);
+      let options = {
+        url,
+        method: method.toUpperCase(),
+        headers: {
+          "X-Coroner-Location": this.coronerLocation,
+          "X-Coroner-Token": this.coronerToken,
+        },
+        qs: actualQs,
+        json: true,
+      };
+      if (body) {
+        options.body = body;
+      }
+      request(options, (err, resp, body) => {
+        if (err) {
+          reject(err);
+        } else {
+          if (resp.statusCode >= 400) {
+            if (body && body.error && body.error.message) {
+              reject(`HTTP status ${resp.statusCode}: ${body.error.message}`);
+            } else {
+              reject(`HTTP status ${ resp.statusCode }`);
+            }
+          } else {
+            resolve(body);
+          }
+        }
+      });
+    });
+  }
+
+  /*
+   * Implements pagination against services using the page_token scheme:
+   * { "values": [ ... ], "next_page_token": "token" }
+   */
+  async *tokenPager({ method, path, body=null, qs = {} }) {
+    /*
+     * Clone this so that if we passed somethingthe caller will still use, we
+     * won't corrupt their state.
+     */
+    qs = { ... qs };
+    let batch = await this.request({ method, path, body, qs });
+    let token;
+    while (batch.values.length > 0) {
+      for (const i of batch.values) {
+        yield i;
+      }
+      token = batch.next_page_token;
+      if (!token) {
+        break;
+      }
+      qs.page_token = token;
+      batch = await this.request({ method, path, body, qs });
+    }
+  }
+}
+
+module.exports = {
+  ServiceClient
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,134 @@
 {
   "name": "backtrace-morgue",
-  "version": "1.19.8",
+  "version": "1.19.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+      "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "@eslint/eslintrc": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.2.1.tgz",
+      "integrity": "sha512-XRUeBZ5zBWLYgSANMpThFddrZZkEbGHgUdt5UJjZfnlN9BGCiUBrf+nvbRupSjMvqzwnQN0qwCmOxITt1cfywA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.19",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "@types/concat-stream": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@types/concat-stream/-/concat-stream-1.6.0.tgz",
@@ -29,6 +154,18 @@
       "version": "6.5.3",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.5.3.tgz",
       "integrity": "sha512-Jugo5V/1bS0fRhy2z8+cUAHEyWOATaz4rbyLVvcFs7+dXp5HfwpEwzF1Q11bB10ApUqHf+yTauxI0UXQDwGrbA=="
+    },
+    "acorn": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+      "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "dev": true
     },
     "ajv": {
       "version": "6.10.2",
@@ -104,6 +241,15 @@
       "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
       "dev": true
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
     },
     "arr-diff": {
       "version": "4.0.0",
@@ -250,6 +396,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
     },
     "async": {
@@ -1130,6 +1282,12 @@
         "unset-value": "^1.0.0"
       }
     },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
+    },
     "camelcase": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
@@ -1394,6 +1552,28 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "dependencies": {
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "csv-writer": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/csv-writer/-/csv-writer-1.6.0.tgz",
@@ -1451,6 +1631,12 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.2.tgz",
       "integrity": "sha1-hLdFiW80xoTpjyzg5Cq69Du6AX0="
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
     },
     "default-compare": {
       "version": "1.0.0",
@@ -1558,6 +1744,15 @@
         "repeating": "^2.0.0"
       }
     },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
     "duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -1595,6 +1790,12 @@
       "integrity": "sha512-NWJ5TztDnjExFISZHFwpoJjMbLUifsNBnx7u2JI0gCw6SbKyQYYWWtBHasO/jPtHym69F4EZuTpRNGN11MT/jg==",
       "dev": true
     },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
     "end-of-stream": {
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
@@ -1602,6 +1803,23 @@
       "dev": true,
       "requires": {
         "once": "^1.4.0"
+      }
+    },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      },
+      "dependencies": {
+        "ansi-colors": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+          "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
+          "dev": true
+        }
       }
     },
     "error-ex": {
@@ -1661,6 +1879,331 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "eslint": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.12.1.tgz",
+      "integrity": "sha512-HlMTEdr/LicJfN08LB3nM1rRYliDXOmfoO4vj39xN6BLpFzF00hbwBoqHk8UcJ2M/3nlARZWy/mslvGEuZFvsg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@eslint/eslintrc": "^0.2.1",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.0",
+        "esquery": "^1.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.19",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "glob-parent": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+          "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        },
+        "globals": {
+          "version": "12.4.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+          "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+          "dev": true,
+          "requires": {
+            "type-fest": "^0.8.1"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+          "dev": true
+        },
+        "slice-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+          "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "astral-regex": "^1.0.0",
+            "is-fullwidth-code-point": "^2.0.0"
+          },
+          "dependencies": {
+            "ansi-styles": {
+              "version": "3.2.1",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+              "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+              "dev": true,
+              "requires": {
+                "color-convert": "^1.9.0"
+              }
+            },
+            "color-convert": {
+              "version": "1.9.3",
+              "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+              "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+              "dev": true,
+              "requires": {
+                "color-name": "1.1.3"
+              }
+            },
+            "color-name": {
+              "version": "1.1.3",
+              "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+              "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+              "dev": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
+            }
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
+        "table": {
+          "version": "5.4.6",
+          "resolved": "https://registry.npmjs.org/table/-/table-5.4.6.tgz",
+          "integrity": "sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.10.2",
+            "lodash": "^4.17.14",
+            "slice-ansi": "^2.1.0",
+            "string-width": "^3.0.0"
+          }
+        }
+      }
+    },
+    "eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
+      "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.2.0",
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
@@ -1834,6 +2377,21 @@
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
+    },
     "file-uri-to-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
@@ -1903,6 +2461,34 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-1.0.1.tgz",
       "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
+      "dev": true
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      },
+      "dependencies": {
+        "rimraf": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+          "dev": true,
+          "requires": {
+            "glob": "^7.1.3"
+          }
+        }
+      }
+    },
+    "flatted": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
+      "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==",
       "dev": true
     },
     "flush-write-stream": {
@@ -2544,6 +3130,12 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
     "get-caller-file": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
@@ -2899,6 +3491,28 @@
       "resolved": "https://registry.npmjs.org/i/-/i-0.3.6.tgz",
       "integrity": "sha1-2WyScyB28HJxG2sQ/X1PZa2O4j0="
     },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3212,6 +3826,16 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
+    "js-yaml": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
@@ -3313,6 +3937,16 @@
       "dev": true,
       "requires": {
         "flush-write-stream": "^1.0.2"
+      }
+    },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
       }
     },
     "liftoff": {
@@ -3555,6 +4189,12 @@
         "to-regex": "^3.0.1"
       }
     },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
     "ncp": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
@@ -3730,6 +4370,20 @@
         "wrappy": "1"
       }
     },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      }
+    },
     "ordered-read-streams": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ordered-read-streams/-/ordered-read-streams-1.0.1.tgz",
@@ -3763,6 +4417,15 @@
       "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
       "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
       "dev": true
+    },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
     },
     "parse-cache-control": {
       "version": "1.0.1",
@@ -3831,6 +4494,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
       "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
     "path-parse": {
@@ -3922,6 +4591,12 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
     "pretty-hrtime": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -3942,6 +4617,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
     },
     "promise": {
       "version": "8.0.3",
@@ -4094,6 +4775,12 @@
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
       }
+    },
+    "regexpp": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "dev": true
     },
     "regexpu-core": {
       "version": "2.0.0",
@@ -4282,6 +4969,12 @@
         "global-modules": "^1.0.0"
       }
     },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
     "resolve-options": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/resolve-options/-/resolve-options-1.1.0.tgz",
@@ -4378,6 +5071,21 @@
           }
         }
       }
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
     },
     "slack-node": {
       "version": "0.1.8",
@@ -4600,6 +5308,12 @@
         "extend-shallow": "^3.0.0"
       }
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
     "sshpk": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
@@ -4708,6 +5422,12 @@
         "is-utf8": "^0.2.0"
       }
     },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
@@ -4781,6 +5501,12 @@
           }
         }
       }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
     },
     "then-request": {
       "version": "5.0.0",
@@ -4943,6 +5669,21 @@
       "integrity": "sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==",
       "dev": true
     },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -5103,6 +5844,12 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
+    "v8-compile-cache": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
+      "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
+      "dev": true
+    },
     "v8flags": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
@@ -5260,6 +6007,12 @@
         }
       }
     },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
@@ -5296,6 +6049,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,11 @@
   "devDependencies": {
     "babel-preset-env": "^1.1.8",
     "del": "^3.0.0",
+    "eslint": "^7.12.1",
     "gulp": "^4.0.2",
     "gulp-babel": "^7.0.1"
+  },
+  "scripts": {
+    "lint": "eslint"
   }
 }


### PR DESCRIPTION
I don't have the bandwidth to finish this before I'm off next week so we might want someone else to take it over.  This PR covers a sizable amount of refactoring, and a working alerts client.  To cut to the chase, the following two commands provision an alert (explanation of the pr follows):


```
./bin/morgue.js alerts target create --project cts \
--name test \
--workflow-name cts-alerts-test

./bin/morgue.js  alerts alert create --name test \
--query-period 1m \
--count fingerprint \
--trigger fingerprint,0,ge,5,10 \
--project cts \
--target-name test \
--enabled \
--min-notification-interval 1m \
--mute-until 0
```

In order to make this happen, and also so that this isn't a huge headache the next time we have to do one of these, we:

- Introduce eslint as a dev dependency, and use their default config to offer developers some optional local linting. I'm not intending to do more with this now, it's intentional that `npm run lint` doesn't specify paths because we can't run it on the whole codebase usefully, and we can figure out better settings later.
- Create a helper module for parsing, validating, and (in some instances) converting options.
- Create a helper base class for service clients, which offers functionality around talking to services in an authenticated way, and a pager which matches Rust
- Lift processing of folds out of `coronerList` in `bin/morgue.js` and into the new module for queries.
- Make our implicit query building steps around timestamps optional (but default on, for API compatibility).

This isn't entirely complete but this should be enough to unblock people. Specifically:

- I've only really tested the create paths.  Update and delete may be weak.
- We probably want some sort of better list, but in general don't have good formatting options for this data.
- There's no docs, and misusing the commands just prints `usage` as a placeholder for the time being.

If someone else doesn't pick this up, I'll address the documentation points and try to get some better testing in when I've got bandwidth again.  Overall, this should be reviewable as-is and it should be possible to work out what it's doing by just reading `lib/alerts/cli.js`, since the refactors underneath all of this get rid of most of the code duplication and leave only code related to alerts in that file.

There's some more targeted information in the individual commits.  I tried to split this up as we would with Phabricator.