### PR TITLE
Support environment variables for better CI integration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ you to upload, download and issue queries on objects with-in the object store.
 
 ## Usage
 
+### Environment Variables
+
+Morgue respects the following environment variables:
+
+- `MORGUE_CONFIG_DIR`: the directory Morgue should write configuration files.
+  Defaults to `~/.morgue`.
+- `MORGUE_USERNAME`, `MORGUE_PASSWORD`: if both are set, suppress interactive
+  login prompts.
+
 ### login
 
 ```
@@ -40,6 +49,11 @@ Logged in.
 ```
 
 At this point, you are able to issue queries.
+
+If you need to log in from a CI context, it is possible to set the
+environment variables `MORGUE_USERNAME` and `MORGUE_PASSWORD`. If these
+variables are set, the interactive prompt will be suppressed, and the values
+in the aforementioned environment variables used instead.
 
 ### clean
 

--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -49,7 +49,8 @@ var endpoint;
 var endpointToken;
 var reverse = 1;
 var ARGV;
-const configDir = path.join(os.homedir(), ".morgue");
+const configDir = process.env.MORGUE_CONFIG_DIR ||
+  path.join(os.homedir(), ".morgue");
 const configFile = path.join(configDir, "current.json");
 
 bt.initialize({
@@ -5951,6 +5952,17 @@ function coronerLogin(argv, config, cb) {
     });
   }
 
+  const loginCb = (username, password) => {
+    coroner.login(username, password, function(err) {
+      loginComplete(coroner, argv, err, cb);
+    })
+  };
+
+  if (process.env.MORGUE_USERNAME && process.env.MORGUE_PASSWORD) {
+    loginCb(process.env.MORGUE_USERNAME, process.env.MORGUE_PASSWORD);
+    return;
+  }
+
   promptLib.get([{
       name: 'username',
       message: 'User',
@@ -5970,11 +5982,7 @@ function coronerLogin(argv, config, cb) {
       }
     }
 
-    coroner.login(result.username, result.password, function(err) {
-      return coroner.login(result.username, result.password, function(err) {
-        loginComplete(coroner, argv, err, cb);
-      });
-    });
+    loginCb(result.username, result.password);
   });
 }
 


### PR DESCRIPTION
Adds `MORGUE_CONFIG_DIR`, `MORGUE_USERNAME`, `MORGUE_PASSWORD`. So:

```
MORGUE_CONFIG_DIR=./morgue MORGUE_USERNAME+user MORGUE_PASSWORD=password morgue login
```

Will create `./morgue/current.json`, and log in without interactive input.