### PR TITLE
Fixes to metrics importer CLI:

### DIFF
--- a/README.md
+++ b/README.md
@@ -1232,6 +1232,7 @@ Which creates the metric in Coronerd against a pre-existing metric group, then:
 
 ```
 morgue metrics-importer importer create \
+--project myproj \
 --source my-source-id \
 --name my-importer \
 --start-at 2020-08-05T00:00:00Z \
@@ -1282,6 +1283,7 @@ used with an importer and displays diagnostic information.  For example:
 
 ```
 morgue metrics-importer source check-query --source my-source-uuid \
+--project myproj \
 --query 'select time, value from test where time >= $1 and time < $2'
 ```
 
@@ -1291,6 +1293,7 @@ Creates an importer.  Takes the following options:
 
 Option         | Description
 -------------- | --------------------------------------------------------------
+--project      | The project of the source.
 --source       | UUUID of the source to associate the importer with.
 --name         | The name of the importer to create.
 --start-at     |  The time to start scraping from in RFC3339 format.
@@ -1302,6 +1305,7 @@ For example:
 
 ```
 morgue metrics-importer importer create \
+--project myproj \
 --source my-source-id \
 --name my-importer \
 --start-at 2020-08-05T00:00:00Z \
@@ -1319,8 +1323,8 @@ documentation for details.
 Displays logs.  Usage:
 
 ```
-morgue metrics-importer logs --source-id my-source-id
-morgue metrics-importer logs --importer-id my-importer-id
+morgue metrics-importer logs --project myproj --source-id my-source-id
+morgue metrics-importer logs --project myproj --importer-id my-importer-id
 ```
 
 You can pass `--limit` to limit the number of returned messages.

--- a/lib/coroner.js
+++ b/lib/coroner.js
@@ -604,8 +604,12 @@ CoronerClient.prototype.find_service = async function (name) {
   /*
    * Config comes from current.json and may be stale. get a new one
    * to find the most recent location of the service.
+   *
+   * The {} here is very important: it's preserving bug compatibility with
+   * get which currently only injects auth params if there's an object to
+   * inject them into.
    */
-  const config = JSON.parse(await this.promise("get", "/api/config", null));
+  const config = JSON.parse(await this.promise("get", "/api/config", {}));
   const serviceEntry = config.services.filter(x => x.name === name)[0];
   if (!serviceEntry) {
     throw new Error(`No ${ name } service is configured`);

--- a/lib/metricsImporter/cli.js
+++ b/lib/metricsImporter/cli.js
@@ -71,7 +71,7 @@ class MetricsImporterCli {
   }
 
   async logs(args) {
-    const project = args._[0];
+    const project = args.project;
     const sourceId = args['source'];
     const importerId = args['importer'];
     let limit = 100;
@@ -124,7 +124,7 @@ class MetricsImporterCli {
   }
 
   async importerCreate(args) {
-    const project = args._[0];
+    const project = args.project;
     const sourceId = args["source"];
     const query = args.query;
     const startAtUnparsed = args["start-at"];
@@ -173,7 +173,7 @@ class MetricsImporterCli {
   }
 
   async sourceCheckQuery(args) {
-    const project = args._[0];
+    const project = args.project;
     const sourceId = args['source'];
     const query = args.query;
 


### PR DESCRIPTION
- Everything takes `--project`.
- Authentication credentials are sent to coronerd when fetching service config.

Identified With @gittheking who also did testing against our in-progress CI integration (because this client isn't yet complete, and the frontend doesn't fully exist, we paired for testing).

Also tweak the readme to make it clear that everything needs `--project`.