### PR TITLE
morgue: Add support for dumping coronerCI output as json to stdout.

### DIFF
--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -739,9 +739,9 @@ function coronerCI(argv, config) {
   let slack;
 
   let universe = argv.universe;
-  if (!universe){
+  if (!universe) {
     universe = Object.keys(config.config.universes)[0];
-}
+  }
 
   let project = argv._[1];
   let value = argv._[2];


### PR DESCRIPTION
Back-porting an internal commit, this allows for dumping the output of the coronerCI function to stdout as json. Rather then creating a markdown post to post to slack.