### PR TITLE
Set query.fold's ts_attr field from variable. Fixes a query bug.

### DIFF
--- a/lib/cli/query.js
+++ b/lib/cli/query.js
@@ -234,9 +234,9 @@ function argvQueryPrefold(argv, implicitTimestampOps) {
       query.select = [ argv.select ];
     }
   } else if (argv.table === 'objects' && implicitTimestampOps) {
-    query.fold = {
-      ts_attr : [['range'], ['bin']]
-    };
+    if (!query.fold)
+      query.fold = {}
+    query.fold[ts_attr] = [['range'], ['bin']]
   }
 
   /*


### PR DESCRIPTION
Javascript-style designated initializers treat keys as string literals, not variables, leading to a small bug.

This PR resolves it.