### PR TITLE
Fix similarity endpoint use.

### DIFF
--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -4755,7 +4755,7 @@ async function coronerSimilarity(argv, config) {
   }
   
   const coroner = coronerClientArgv(config, argv);
-  const similarityEndpoint = `${coroner.endpoint}${similarityService.endpoint}`;
+  const similarityEndpoint = similarityService.endpoint;
 
   if (argv._.length < 2) {
     return usage("Missing project, universe arguments.");


### PR DESCRIPTION
Backtrace returns a full URL for `similarity` endpoint, thus we shouldn't concatenate it with the general endpoint.
```
      {
        "name": "similarity",
        "endpoint": "https://similarity.backtrace.io/api/similarity"
      },
```