### PR TITLE
colors: Fix import of red color from chalk lib

### DIFF
--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -43,6 +43,7 @@ const grey = chalk.grey;
 const yellow = chalk.yellow;
 const blue = chalk.blue;
 const green = chalk.green;
+const red = chalk.red;
 const label_color = yellow.bold;
 
 var flamegraph = path.join(__dirname, "..", "assets", "flamegraph.pl");


### PR DESCRIPTION
Incomplete switchover from colors module to chalk in commit 3db270d2c8ce5c273d064397211b2df14d3b7909

This should fix that in the use case of `morgue setup`