### PR TITLE
Refactor coronerSetup to improve error handling.

### DIFF
--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -634,12 +634,23 @@ function coronerSetup(argv, config) {
     if (response === 0) {
       process.stderr.write(red('unconfigured\n'));
       return coronerSetupStart(coroner, argv);
-    } else {
+    } else if (response === 1) {
       process.stderr.write(green('configured\n\n'));
 
       console.log(bold('Please login to continue setup.'));
       return coronerLogin(argv, config, coronerSetupStart);
-    }
+    } else {
+		process.stderr.write(red('\n\nUnexpected response when checking the server\'s status.\n\n'));
+		process.stderr.write(red('This could be caused by one of the following:\n'));
+		process.stderr.write(red('  * Either the coronerd or backtrace-nginx services are not running on the server, or are in a failed state.\n'));
+		process.stderr.write(red('  * A proxy or forwarder is handling the request and is returning a response that the morgue client cannot understand.\n'));
+		process.stderr.write(red('  * Certificate validation is failing when trying to communicate with the server (try using -k if using self-signed certificates).\n'));
+		process.stderr.write(red('  * The destination URL is incorrect.\n'));
+		process.stderr.write(red('\n'));
+		process.stderr.write(red('To view the response from the server, try running the following command:\n'));
+		process.stderr.write(red('  curl ' + argv._[1] + '/api/is_configured\n'));
+		process.exit(1);
+	}
   });
 }
 


### PR DESCRIPTION
This commit modifies coronerSetup to enhance error handling and provide a more informative error message when receiving an unexpected response (anything other than 0 or 1) from the is_configured API call.

This is a frequent scenario if the Backtrace service isn't running, or if a proxy returns an error webpage.  In these cases, a simple 0 or 1 aren't received in the response, then morgue mistakenly thinks the system is "configured".