### PR TITLE
add select-wildcard

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ data.
 
 The `--csv=<output file>` option may be passed in with a specified output
 file to output results to a CSV file instead. This may only be used with
-`--select` queries.
+`--select` and/or `--select-wildcard` queries.
 
 #### Filters
 
@@ -213,6 +213,19 @@ Pagination is handled with two flags
 `--limit=<n>` controls the number of returned rows. `--offset=<n>` controls the
 offset at which rows are returned, another way to put it is that it skips the
 first `<n>` rows.
+
+#### Selection
+
+Selection can be done with two options, `--select=<attribute>` and 
+`--select-wildcard=<physical|derived|virtual>`. 
+
+`--select` allows to select particular attributes, while `--select-wildcard` selects
+all attributes that match the option.
+
+Wildcards can be one of:
+* `physical` - selects all attributes that are physically stored in objects,
+* `derived` - selects all derived attributes, such as `first_seen` or `original`,
+* `virtual` - selects all virtual (join) attributes.
 
 #### Aggregations
 
@@ -247,7 +260,7 @@ syntax is `[-](<column>|<fold_term>)`.
 - The optional `-` reverse the sort term order to descending, otherwise it
   defaults to ascending.
 - The `<column>` term refers to a valid column in the table. This is only
-  effective for selection type query, i.e. when using the `--select` option.
+  effective for selection type query, i.e. when using the `--select` and/or `--select-wildcard` option.
 - The `<fold_term>` is an expression pointing to a fold operation. The
   expression language for fold operation is one of the following literal:
     - `;group`: sort by the group key itself.
@@ -1493,10 +1506,10 @@ Update also supports the following arguments:
 
 The create and update subcommands allow specifying the query using the same
 arguments as the `morgue list` command, save that `--age` is ignored,
-`--select` isn't allowed, and any implicit time filtering that Morgue would
-otherwise apply is disabled.  Since empty CLI arguments are a valid query,
-update additionally requires supplying `--replace-query` to indicate that the
-query is being replaced.
+`--select` or `--select-wildcard` isn't allowed, and any implicit time filtering
+that Morgue would otherwise apply is disabled.  Since empty CLI arguments are 
+a valid query, update additionally requires supplying `--replace-query` to indicate 
+that the query is being replaced.
 
 The alerts service itself can only function properly with aggregation queries
 that use aggregates which support a single value. For example `count` is fine,

--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -5719,8 +5719,8 @@ function coronerList(argv, config) {
   }
 
   let csv = argv.csv;
-  if (csv && !argv.select)
-      return usage("--csv requires select parameters")
+  if (csv && !argv.select && !argv['select-wildcard'])
+      return usage("--csv requires select or select-wildcard parameters")
 
   p = coronerParams(argv, config);
 

--- a/lib/alerts/cli.js
+++ b/lib/alerts/cli.js
@@ -244,7 +244,7 @@ class AlertsCli {
 
     const query = queryCli.argvQuery(argv, /*implicitTimestampOps=*/false,
       /*doFolds=*/true).query;
-    if (query.select) {
+    if (query.select || query['select-wildcard']) {
       errx("Alerts only work on aggregation queryes");
     }
 
@@ -285,7 +285,7 @@ class AlertsCli {
     if (argv['replace-query']) {
       const query = queryCli.argvQuery(argv, /*implicitTimestampOps=*/false,
         /*doFolds=*/true).query;
-      if (query.select) {
+      if (query.select || query['select-wildcard']) {
         errx("Alerts only work with aggregation queries");
       }
       updated.query = JSON.stringify(query);

--- a/lib/cli/query.js
+++ b/lib/cli/query.js
@@ -48,9 +48,9 @@ function argvVcols(args) {
 
 /* Some subcommands don't make sense with folds etc. */
 function argvQueryFilterOnly(argv) {
-  if (argv.select || argv.filter || argv.fingerprint || argv.age || argv.time) {
+  if (argv.select || argv.filter || argv.fingerprint || argv.age || argv.time || argv['select-wildcard']) {
     /* Object must be returned for query to be chainable. */
-    if (!argv.select && !argv.template) {
+    if (!argv.select && !argv['select-wildcard'] && !argv.template) {
       argv.select = 'object';
     }
     return argvQuery(argv);
@@ -224,16 +224,29 @@ function argvQueryPrefold(argv, implicitTimestampOps) {
   query.virtual_columns = argvVcols(argv);
 
   if (argv.template === 'select') {
-  } else if (argv.select) {
-    if (!query.select)
-      query.select = [];
+  } else if (argv.select || argv['select-wildcard']) {
+    if (argv.select) {
+      if (!query.select)
+        query.select = [];
 
-    if (Array.isArray(argv.select) === true) {
-      for (let i = 0; i < argv.select.length; i++) {
-        query.select.push(argv.select[i]);
+      if (Array.isArray(argv.select) === true) {
+        for (let i = 0; i < argv.select.length; i++) {
+          query.select.push(argv.select[i]);
+        }
+      } else {
+        query.select = [argv.select];
       }
-    } else {
-      query.select = [ argv.select ];
+    }
+
+    if (argv['select-wildcard']) {
+      if (!query.select_wildcard) {
+        query.select_wildcard = {};
+      }
+
+      var wildcards = Array.isArray(argv['select-wildcard']) ? argv['select-wildcard'] : [argv['select-wildcard']];
+      for (let i = 0; i < wildcards.length; i++) {
+        query.select_wildcard[wildcards[i]] = true;
+      }
     }
   } else if (argv.table === 'objects' && implicitTimestampOps) {
     if (!query.fold)


### PR DESCRIPTION
This PR adds `--select-wildcard` option, which adds `select_wildcard` to the CRDB query.

This allows to select all attributes available in CRDB that match the wildcard criteria.

New usage:
```
> morgue list project --select-wildcard physical --select-wildcard derived
```