### PR TITLE
add CLI for Workflows management

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ npm install backtrace-morgue -g
 ```
 
 If you working from the repository, then instead use the following command.
+
 ```
 npm install -g
 ```
@@ -102,9 +103,9 @@ to standard output. Optionally, output the file to disk.
 
 The following options are available:
 
-| Option        | Description |
-|---------------|-------------|
-| `--resource=name`| Fetch the specified resource rather than the object. |
+| Option            | Description                                          |
+| ----------------- | ---------------------------------------------------- |
+| `--resource=name` | Fetch the specified resource rather than the object. |
 
 ### put
 
@@ -114,13 +115,13 @@ Usage: morgue put <[<universe>/]project> <file> <--format=btt|minidump|json|symb
 
 Uploads object file to the Backtrace object store. User has the following options
 
-| Option        | Description |
-|---------------|-------------|
-| `--compression=gzip|deflate`| uploaded file is compressed |
-| `--kv=key1:value1,key2:value2,...`| upload key-values |
-| `--form_data`| upload file by multipart/form-data post request |
+| Option                             | Description                                     |
+| ---------------------------------- | ----------------------------------------------- | --------------------------- |
+| `--compression=gzip                | deflate`                                        | uploaded file is compressed |
+| `--kv=key1:value1,key2:value2,...` | upload key-values                               |
+| `--form_data`                      | upload file by multipart/form-data post request |
 
-### set 
+### set
 
 ```
 Usage: morgue set <[universe/]project> <query> <key>=<value>
@@ -216,41 +217,42 @@ first `<n>` rows.
 
 #### Selection
 
-Selection can be done with two options, `--select=<attribute>` and 
-`--select-wildcard=<physical|derived|virtual>`. 
+Selection can be done with two options, `--select=<attribute>` and
+`--select-wildcard=<physical|derived|virtual>`.
 
 `--select` allows to select particular attributes, while `--select-wildcard` selects
 all attributes that match the option.
 
 Wildcards can be one of:
-* `physical` - selects all attributes that are physically stored in objects,
-* `derived` - selects all derived attributes, such as `first_seen` or `original`,
-* `virtual` - selects all virtual (join) attributes.
+
+- `physical` - selects all attributes that are physically stored in objects,
+- `derived` - selects all derived attributes, such as `first_seen` or `original`,
+- `virtual` - selects all virtual (join) attributes.
 
 #### Aggregations
 
 Aggregation is expressed through a myriad of command-line options that express
 different aggregation operations. Options are of form `--<option>=<attribute>`.
 
-The ``*`` factor is used when aggregations are performed when no factor is
+The `*` factor is used when aggregations are performed when no factor is
 specified or if an object does not have a valid value associated with the
 factor.
 
-| Option           | Description |
-|------------------|-------------|
-| `--age`          | Specify a relative timestamp to now. `1h` ago, or `1d` ago. |
+| Option           | Description                                                               |
+| ---------------- | ------------------------------------------------------------------------- |
+| `--age`          | Specify a relative timestamp to now. `1h` ago, or `1d` ago.               |
 | `--time`         | Specify a range using [Chrono](https://github.com/wanasit/chrono#readme). |
-| `--unique`       | provide a count of distinct values |
-| `--histogram`    | provide all distinct values |
-| `--distribution` | provide a truncated histogram |
-| `--mean`    	   | calculate the mean of a column |
-| `--sum`          | sum all values |
-| `--range`        | provide the minimum and maximum values |
-| `--count`        | count all non-null values |
-| `--bin`          | provide a linear histogram of values |
-| `--head`         | provide the first value in a factor |
-| `--tail`         | provide the last value in a factor |
-| `--object`       | provide the maximum object identifier of a column |
+| `--unique`       | provide a count of distinct values                                        |
+| `--histogram`    | provide all distinct values                                               |
+| `--distribution` | provide a truncated histogram                                             |
+| `--mean`         | calculate the mean of a column                                            |
+| `--sum`          | sum all values                                                            |
+| `--range`        | provide the minimum and maximum values                                    |
+| `--count`        | count all non-null values                                                 |
+| `--bin`          | provide a linear histogram of values                                      |
+| `--head`         | provide the first value in a factor                                       |
+| `--tail`         | provide the last value in a factor                                        |
+| `--object`       | provide the maximum object identifier of a column                         |
 
 #### Sorting
 
@@ -263,10 +265,10 @@ syntax is `[-](<column>|<fold_term>)`.
   effective for selection type query, i.e. when using the `--select` and/or `--select-wildcard` option.
 - The `<fold_term>` is an expression pointing to a fold operation. The
   expression language for fold operation is one of the following literal:
-    - `;group`: sort by the group key itself.
-    - `;count`: sort by the group count (number of crashes).
-    - `column;idx`: where `column` is a string referencing a column in the fold
-      dictionary and `idx` is an indice in the array. See examples .
+  - `;group`: sort by the group key itself.
+  - `;count`: sort by the group count (number of crashes).
+  - `column;idx`: where `column` is a string referencing a column in the fold
+    dictionary and `idx` is an indice in the array. See examples .
 
 Multiple sort terms can be provided to break ties in case the previous
 referenced sort term has ties.
@@ -285,7 +287,7 @@ Forms:
 --quantize-uint output_column,input_column,size,offset
 ```
 
-Computes `( column + offset ) / size - offset` using integer math.  Used for
+Computes `( column + offset ) / size - offset` using integer math. Used for
 data alignment and rounding.
 
 Size and offset may be integers or time units: `3600` and `1h` are both valid.
@@ -433,8 +435,8 @@ Object IDs must be specified; they can be found in `morgue list` output.
 The object ID printed in the example above is `9d33`.
 
 By default, this command (as of 2019-02-26) requests physical-only deletion,
-which retains only indexing.  The previous `--physical-only` argument is a
-no-op.  The following options affect this behavior:
+which retains only indexing. The previous `--physical-only` argument is a
+no-op. The following options affect this behavior:
 `--all`: Delete all related data, including indexing.
 `--crdb-only`: Only delete the indexed data; requires physically deleted objects.
 
@@ -471,8 +473,6 @@ http://www.brendangregg.com/flamegraphs.html.
 Use `--unique` to only sample unique crashes. Use `--reverse` to begin sampling
 from leaf functions.
 
-
-
 ### symbold
 
 Manage Backtrace symbold service
@@ -481,63 +481,82 @@ Manage Backtrace symbold service
 Usage: morgue symbold <symbolserver | whitelist | blacklist | skiplist | status> <action>
 ```
 
-
 #### status
+
 Return Symbold service status for <[universe]/project>
+
 ```
 Usage: morgue symbold status <[universe]/project>
 ```
 
 #### symbolserver
+
 Symbol server allows you to manage symbol servers used by symbold
 
 #### list
+
 List Symbold symbol server assigned to <[universe]/project>
+
 ```
 Usage: morgue symbold symbolserver list <[universe]/project>
 ```
+
 Example:
+
 ```
 $ morgue symbold symbolserver list backtrace
 ```
 
 #### details
+
 Retruns detailed information about symbol server
+
 ```
 Usage: morgue symbold symbolserver details [symbolserverid]
 ```
 
 Example:
+
 ```
 $ morgue symbold symbolserver details 1
-``` 
+```
+
 Command line above will return detailed information for symbol server with id 1
 
 #### logs
+
 Returns symbol server logs. You can use page and take arguments to get more/less logs.
+
 ```
 Usage: morgue symbold symbolserver logs [symbolserverid]
 ```
 
 Example:
+
 ```
 $ morgue symbold symbolserver logs 1 --take=100 --page=0
 ```
+
 Command above will return first 100 logs from page 0
 
 #### filter logs
+
 Returns filtered symbol server logs. By using this command you can filter all logs that match your criteria.
+
 ```
 Usage morgue symbold symbolserver logs [symbolserverid] filter [filter]
 ```
 
 Example:
+
 ```
 morgue.js symbold symbolserver logs 5 filter a --take=100 --page=1
 ```
+
 #### add
+
 ```
-Usage: morgue symbold symbolserver add <[universe]/project> [symbolserverurl] 
+Usage: morgue symbold symbolserver add <[universe]/project> [symbolserverurl]
   <--name=...>
   <--concurrentdownload=...>
   <--retrylimit=...>
@@ -557,35 +576,38 @@ Usage: morgue symbold symbolserver add <[universe]/project> [symbolserverurl]
   <--proxy.username=...>
   <--proxy.password=...>
 ```
-Add new symbol server to symbold service. Available options:
-* `name` - symbol server name,
-* `concurrentdownload` - maximum number of concurrent download that symbolmd will do at the same time,
-* `timeout` - download timeout
-* `whitelist` - determine if symbol server should use whitelist or not,
-* `retain` - determine if symbold should retain original symbols
-* `servercredentials` - symbol server auth options
-* `servercredentials.username` - symbol server auth user name,
-* `servercredentials.password` - symbol server auth password,
-* `aws.accesskey` - AWS S3 access key
-* `aws.secret` - AWS S3 secret
-* `aws.bucketname` - AWS S3 bucket name
-* `aws.lowerfile` - determine if symbold should use lower case symbol name
-* `aws.lowerid` - - determine if symbold should use lower case debug id
-* `aws.usepdb` - determine a way to generate url to S3 symbols
-* `proxy.host` - proxy host
-* `proxy.port` - proxy port
-* `proxy.username` - proxy username
-* `proxy.password` - proxy password
 
+Add new symbol server to symbold service. Available options:
+
+- `name` - symbol server name,
+- `concurrentdownload` - maximum number of concurrent download that symbolmd will do at the same time,
+- `timeout` - download timeout
+- `whitelist` - determine if symbol server should use whitelist or not,
+- `retain` - determine if symbold should retain original symbols
+- `servercredentials` - symbol server auth options
+- `servercredentials.username` - symbol server auth user name,
+- `servercredentials.password` - symbol server auth password,
+- `aws.accesskey` - AWS S3 access key
+- `aws.secret` - AWS S3 secret
+- `aws.bucketname` - AWS S3 bucket name
+- `aws.lowerfile` - determine if symbold should use lower case symbol name
+- `aws.lowerid` - - determine if symbold should use lower case debug id
+- `aws.usepdb` - determine a way to generate url to S3 symbols
+- `proxy.host` - proxy host
+- `proxy.port` - proxy port
+- `proxy.username` - proxy username
+- `proxy.password` - proxy password
 
 Example:
+
 ```
 $ morgue symbold symbolserver backtrace https://symbol.server.com --name=name --timeout=400
 ```
 
 #### update
+
 ```
-Usage: morgue symbold symbolserver update [symbolserverid] 
+Usage: morgue symbold symbolserver update [symbolserverid]
   <--url=...>
   <--name=...>
   <--concurrentdownload=...>
@@ -606,111 +628,142 @@ Usage: morgue symbold symbolserver update [symbolserverid]
   <--argv.proxy.username=...>
   <--argv.proxy.password=...>
 ```
-Update  symbol server with id [symbolServerId]. If aws, proxy and servercredentials data doesn't exists symbold will ignore update server credentials. If any of them exists, symbold will try to update all properties.
+
+Update symbol server with id [symbolServerId]. If aws, proxy and servercredentials data doesn't exists symbold will ignore update server credentials. If any of them exists, symbold will try to update all properties.
 Example:
+
 ```
 $ morgue symbold symbolserver update 1 --url="http://new.symbol.server.url"
 ```
 
 #### disable
-Disable symbol server. Symbold won't use disabled symbol server. 
-```
-Usage: morgue symbold symbolserver disable [symbolserverid] 
-```
+
 Disable symbol server. Symbold won't use disabled symbol server.
 
-#### enable 
-Enable symbol server. Symbold won't use disabled symbol server. 
+```
+Usage: morgue symbold symbolserver disable [symbolserverid]
+```
+
+Disable symbol server. Symbold won't use disabled symbol server.
+
+#### enable
+
+Enable symbol server. Symbold won't use disabled symbol server.
+
 ```
 Usage: morgue symbold symbolserver enable [symbolserverid]
 ```
+
 Enable symbol server.
 
 #### whitelist/blacklist/skiplist
 
-##### add 
+##### add
+
 Add new element to whitelist/blacklist
+
 ```
 Usage: morgue symbold [whitelist|blacklist] [--name=...]
 ```
+
 Add new element to blacklist/whitelist
 
+##### remove
 
-##### remove 
 Remove element from skiplist/blacklist/skiplist by using element id
+
 ```
 Usage : morgue symbold [whitelist|blacklist|skiplist] [--itemid=...]
 ```
 
-##### list 
+##### list
+
 List <--take> elements from [whitelist|blacklist|skiplist] from <--page> page
+
 ```
 Usage: morgue symbold [whitelist|blacklist|skiplist] <--page=...> <--take=...>
 ```
 
-
 #### skiplist [only]
 
-##### find 
+##### find
+
 Find elements in skiplist
+
 ```
 morgue symbold skiplist find [symbolServerId] [filter] <--page=...> <--take=...>
 ```
-Usage: 
+
+Usage:
+
 ```
-$ morgue symbold skiplist find 5 sample.dll 
+$ morgue symbold skiplist find 5 sample.dll
 ```
 
+##### remove all
 
-##### remove all 
 Remove all elements in skiplist
+
 ```
 morgue symbold skiplist remove all [symbolServerId]
 ```
-Usage: 
+
+Usage:
+
 ```
 $ morgue symbold skiplist remove all 5
 ```
 
 ##### remove by filter
-Remove all elements in skiplist that match filter criteria  
+
+Remove all elements in skiplist that match filter criteria
+
 ```
 morgue symbold skiplist remove all [symbolServerId]
 ```
-Usage: 
+
+Usage:
+
 ```
 $ morgue symbold skiplist remove all 5
 ```
 
-
 #### queue
+
 Symbold queue commands
 
-##### list 
+##### list
+
 returns all events in symbold queue
+
 ```
-Usage: morgue symbold queue list 
+Usage: morgue symbold queue list
 ```
 
 ##### Add
-Add event on the top of symbold queue 
+
+Add event on the top of symbold queue
+
 ```
-morgue symbold queue <add | create> <universe/project> <missingSymbol> <objectId> 
+morgue symbold queue <add | create> <universe/project> <missingSymbol> <objectId>
 ```
+
 Usage:
+
 ```
 $ morgue symbold queue add universe/project "a.pdb,123" 123
 ```
 
 ##### Size
+
 Returns queue size - how many reports symbold still have to reprocess
 
 ```
 Usage: morgue symbold queue size
 ```
 
-
 ##### Symbold
+
 List all missing symbols from symbold events
 
 ```
@@ -740,6 +793,7 @@ Usage: morgue report <project> create
 ```
 
 Example:
+
 ```
 $ morgue report MyProject create --rcpt=null@backtrace.io
     --rcpt=list@backtrace.io --filter=environment,equal,prod
@@ -797,11 +851,11 @@ Options for reprocess:
   --last=N         Specify the last object ID (default: most recent known)
 ```
 
-Reprocess the project's objects.  This command can be used to re-execute
+Reprocess the project's objects. This command can be used to re-execute
 indexing, fingerprinting, and symbolification (where needed).
 
 If a set of objects (or query) is specified, any values for `--first` and
-`--last` are replaced to match the object list.  If no query, object list,
+`--last` are replaced to match the object list. If no query, object list,
 or range is provided, all objects in the project are reprocessed.
 
 ### retention
@@ -872,6 +926,7 @@ $
 ```
 
 Set instance policy to compress after 7 days:
+
 ```
 $ morgue retention set --type=instance --max-age=7d --compress
 success
@@ -902,9 +957,9 @@ Project is a required flag if fingerprint is specified.
 #### Configuring Sampling (Coronerd 1.50+)
 
 In Coronerd 1.50, it became possible to configure sampling on a per-project
-basis as well as using `coronerd.conf`.  This is done with the
+basis as well as using `coronerd.conf`. This is done with the
 `morgue sampling configure` command. Configurations specified on projects
-override the `coronerd.conf` settings.  For example:
+override the `coronerd.conf` settings. For example:
 
 ```
 morgue sampling configure --project myproject \
@@ -933,7 +988,7 @@ The available options are as follows:
 - `--backoff count,interval`: Specify a backoff entry. This option must be
   specified at least once, multiple instances must be specified in
   increasing order of interval, and the first backoff must always have a `0`
-  interval.  `interval` supports time units: `1d`, etc.
+  interval. `interval` supports time units: `1d`, etc.
 - `--buckets`: The maximum number of sampling buckets to allow. Optional,
   default 512.
 - `--process-whitelisted true|false`: whether to sample objects with
@@ -1005,10 +1060,11 @@ Usage: morgue token create --project=<project> --capability=<capability>
 ```
 
 Capability can be any of:
- * symbol:post - Enable symbol uploads with the specified API token.
- * error:post  - Enable error and dump submission with the specified API token.
- * query:post  - Enable queries to be issued using the specified token.
- * sync:post   - Allow for slower but more verbose submission.
+
+- symbol:post - Enable symbol uploads with the specified API token.
+- error:post - Enable error and dump submission with the specified API token.
+- query:post - Enable queries to be issued using the specified token.
+- sync:post - Allow for slower but more verbose submission.
 
 Multiple capabilities can be specified by using `--capability` multiple times
 or using a comma-separated list.
@@ -1041,15 +1097,16 @@ Usage: morgue user reset [--universe=...] [--user=...] [--password=...] [--role=
 ### users
 
 Add signup domain whitelist.
+
 ```
 Usage: morgue users add-signup-whitelist [--universe=...] [--domain=...] [--role=...] [--method=...]
 ```
 
 List users that are not associated with a team.
+
 ```
 Usage: morgue users list-teamless-users
 ```
-
 
 ### tenant
 
@@ -1123,14 +1180,14 @@ to their callstack attribute.
 Usage: morgue similarity <[universe]/project> [filter expression]
     [--threshold=N]     The minimum length of the callstack for groups to
                         consider for similarity analysis.
-    [--truncate=N]      Shorten the callstack before comparing.   
+    [--truncate=N]      Shorten the callstack before comparing.
     [--intersection=N]  The minimum number of common symbols between
                         two groups.
     [--distance=N]      The maximum acceptable edit distance between
                         two groups.
     [--fingerprint=N]   A fingerprint to compute similarity to. If omitted,
-                        a project summary will be computed instead. 
-    [--json]            Return the JSON result of the similarity request.                
+                        a project summary will be computed instead.
+    [--json]            Return the JSON result of the similarity request.
 ```
 
 ### invite
@@ -1233,6 +1290,7 @@ $ morgue callstack evaluate project file.json
 ## Access control
 
 Allows controlling coroner's access control mechanisms
+
 ```
 Usage:
 morgue access <action> [params...]
@@ -1256,12 +1314,15 @@ action project:
 ```
 
 ### action team
+
 Allows manipulation of teams - creation, removal, listing, displaying details and adding/removing users to teams.
 
 ### action project
+
 Allows manipulation of projects in terms of access control - display details or add/remove user or team.
 
 Possible roles:
+
 - admin
 - member
 - guest
@@ -1273,13 +1334,13 @@ the highest privileges afforded by any of those access routes.
 ## Stability Score and Storing Metrics Data
 
 Morgue offers the ability to configure metrics for importing metrics data with
-`metrics-importer` or custom API integrations.  This can be used from CI to
-provision new metrics against a metric group and begin shipping data.  At the
+`metrics-importer` or custom API integrations. This can be used from CI to
+provision new metrics against a metric group and begin shipping data. At the
 moment, Morgue assumes setup and most common operations on entities for
 metrics importing are carried out through the frontend and only offers the
 subset of functionality necessary for automation from CI.
 
-Generally, the typical flow occurs in two stages.  First:
+Generally, the typical flow occurs in two stages. First:
 
 ```
 morgue stability create-metric --project myproj --metric-group stability \
@@ -1321,12 +1382,12 @@ This will provision a metric on the Coronerd side that can be fed via
 timeseries submission endpoints.
 
 Attribute values are of the form `--attribute name,value`.
-An attribute value must be specified for every non-defaulted attribute 
+An attribute value must be specified for every non-defaulted attribute
 on the group.
 
 ### Controlling `metrics-importer`
 
-It is possible to use Morgue to configure importers for stability score.  This
+It is possible to use Morgue to configure importers for stability score. This
 requires Coronerd >= 1.48 and a deployed backtrace-metrics-importer.
 Usage:
 
@@ -1337,7 +1398,7 @@ morgue metrics-importer <command>...
 #### `source check-query`
 
 Determines if a query is valid by running it against a source as if it had been
-used with an importer and displays diagnostic information.  For example:
+used with an importer and displays diagnostic information. For example:
 
 ```
 morgue metrics-importer source check-query --source my-source-uuid \
@@ -1347,17 +1408,17 @@ morgue metrics-importer source check-query --source my-source-uuid \
 
 #### `importer create`
 
-Creates an importer.  Takes the following options:
+Creates an importer. Takes the following options:
 
-Option         | Description
--------------- | --------------------------------------------------------------
---project      | The project of the source.
---source       | UUID of the source to associate the importer with.
---name         | The name of the importer to create.
---start-at     |  The time to start scraping from in RFC3339 format.
---metric       | The name of the metric to associate data with in Coronerd.
---metric-group | The name of the metric group to associate data with in Coronerd.
---delay        | The delay of the importer. Defaults to 60.
+| Option         | Description                                                      |
+| -------------- | ---------------------------------------------------------------- |
+| --project      | The project of the source.                                       |
+| --source       | UUID of the source to associate the importer with.               |
+| --name         | The name of the importer to create.                              |
+| --start-at     | The time to start scraping from in RFC3339 format.               |
+| --metric       | The name of the metric to associate data with in Coronerd.       |
+| --metric-group | The name of the metric group to associate data with in Coronerd. |
+| --delay        | The delay of the importer. Defaults to 60.                       |
 
 For example:
 
@@ -1373,12 +1434,12 @@ morgue metrics-importer importer create \
 --delay 120
 ```
 
-Note that `--query` depends on the source type.  See the stability score
+Note that `--query` depends on the source type. See the stability score
 documentation for details.
 
 #### `logs`
 
-Displays logs.  Usage:
+Displays logs. Usage:
 
 ```
 morgue metrics-importer logs --project myproj --source-id my-source-id
@@ -1387,7 +1448,6 @@ morgue metrics-importer logs --project myproj --importer-id my-importer-id
 
 You can pass `--limit` to limit the number of returned messages.
 By default `--limit` is 100.
-
 
 # Alerts
 
@@ -1405,8 +1465,7 @@ Details follow.
 
 Let's say that you want to create an alert which will fire if there ware more
 than 5 errors in the last minute, and will mark groups as critical if more than
-10 errors occur.  To do so:
-
+10 errors occur. To do so:
 
 Start by creating a target if you don't already have one:
 
@@ -1435,7 +1494,7 @@ morgue  alerts alert create --name test \
 
 All alerting subcommands which refer to an object support identifying objects
 through either their name or ID, and take two mutually exclusive parameters:
-`--name` or `--id`.  For instance:
+`--name` or `--id`. For instance:
 
 ```
 morgue alerts alert get --name myalert
@@ -1460,7 +1519,7 @@ morgue alerts target update --name my-target [--rename new-name]
   [--workflow-name new-workflow]
 ```
 
-Create and manage targets.  Note that since Morgue allows identifying objects
+Create and manage targets. Note that since Morgue allows identifying objects
 through `--name`, it is necessary to use `--rename` to change the name.
 
 ## Alert Creation And Update
@@ -1470,25 +1529,26 @@ morgue alerts alert create <args>
 morgue alert alerts update <args>
 ```
 
-Create and update alerts.  Create requires all of the following
+Create and update alerts. Create requires all of the following
 parameters which don't have defaults, while update patches the object with
 those specified and has no required parameters beyond identifying the alert to
-apply to.  Parameters are as follows (see below for query and trigger
+apply to. Parameters are as follows (see below for query and trigger
 specification):
 
 -`--name`: For create, the name of the new alert. For update, identify the
-  alert to modify by name.
+alert to modify by name.
+
 - `--enabled true|false`: whether the alert is enabled. Defaults to `true` for
   create.
--- `--query-period = <timespec>`: the query period. Supports time specifications
+  -- `--query-period = <timespec>`: the query period. Supports time specifications
   in the same fashion as `morgue list --age`: `5m`, `1h`, etc.
   Note that the service puts a lower bound of 1 minute on this value.
 - `--min-notification-interval`: the minimum notification interval, which
   controls the maximum interval at which an alert can send notifications to an
   integration.
 - `--mute-until`: Unix timestamp. The alert will be silenced until after this
-  timestamp.  The timestamp must currently be specified as integer seconds
-  since the Unix epoch.  For create, defaults to 0, which doesn't mute
+  timestamp. The timestamp must currently be specified as integer seconds
+  since the Unix epoch. For create, defaults to 0, which doesn't mute
   the alert.
 - `--target-id`: Specified zero or more times to indicate the targets to which
   to send the alert. Unioned with `--target-names`.
@@ -1507,8 +1567,8 @@ Update also supports the following arguments:
 The create and update subcommands allow specifying the query using the same
 arguments as the `morgue list` command, save that `--age` is ignored,
 `--select` or `--select-wildcard` isn't allowed, and any implicit time filtering
-that Morgue would otherwise apply is disabled.  Since empty CLI arguments are 
-a valid query, update additionally requires supplying `--replace-query` to indicate 
+that Morgue would otherwise apply is disabled. Since empty CLI arguments are
+a valid query, update additionally requires supplying `--replace-query` to indicate
 that the query is being replaced.
 
 The alerts service itself can only function properly with aggregation queries
@@ -1525,16 +1585,387 @@ The `--trigger` option has the form:
 
 Alerts identifies aggregates to trigger on by their column name, and the index
 in the same fashion as `--sort` on list, though `;count` is unsupported (for
-that, ad a `--count column` aggregate).  The components of a trigger are as
+that, ad a `--count column` aggregate). The components of a trigger are as
 follows:
 
 - `column`: The column the trigger is for, for example `fingerprint`.
 - `index`: The index of the aggregate for the specified column.
 - `comparison`: Either `ge` or `le`. Controls whether the thresholds are `>==>
-  or `<=` the query's returned values.  Most triggers will use `ge`.
+or `<=`the query's returned values.  Most triggers will use`ge`.
 - `warning`: the warning threshold for the trigger.
 - `critical`: The critical threshold for the trigger.
 
+## Workflows
+
+Morgue supports managing workflow connections, integrations, and alerts, by using following subcommands:
+
+```
+morgue workflows connection [create | list | get | update | delete] <options>
+morgue workflows integration [create | list | get | update | delete] <options>
+morgue workflows alert [create | list | get | update | delete] <options>
+```
+
+### Managing connections
+
+Managing connections requires an universe to be specified.
+If it is not set via config or login, specify it by `--universe`.
+
+#### List connections
+
+```
+morgue workflows connection list [options]
+```
+
+Options:
+
+- `--raw` - `boolean` - output raw JSON
+
+Example:
+
+```
+morgue workflows connection list --raw
+```
+
+#### Get one connection
+
+```
+morgue workflows connection get [options] <connection id>
+```
+
+Options:
+
+- `--raw` - `boolean` - output raw JSON
+
+Example:
+
+```
+morgue workflows connection get 10
+```
+
+#### Create a connection
+
+```
+morgue workflows connection create <options>
+```
+
+By using `--from-file`, you can load connection spec from file.
+Arguments provided by CLI will override the file spec, but they may not be required anymore.
+
+Options:
+
+- `--name` - `string` - connection name, required
+- `--plugin` - `string` plugin ID, required
+- `--options` - `object` - connection options specific to plugin ID, required
+- `--from-file` - `string` - load connection spec from file
+- `--raw` - `boolean` - output raw JSON
+
+Example:
+
+```
+morgue workflows connection create \
+  --name myConnection \
+  --plugin jira \
+  --options.baseUrl https://my-jira.atlassian.net \
+  --options.authorizationOptions.type basic \
+  --options.authorizationOptions.username user \
+  --options.authorizationOptions.password myPassword
+```
+
+#### Update a connection
+
+```
+morgue workflows connection update <options> <connection id>
+```
+
+By using `--from-file`, you can load connection spec from file.
+Arguments provided by CLI will override the file spec, but they may not be required anymore.
+
+Options:
+
+- `--name` - `string` - connection name, if updated
+- `--options` - `object` - partial connection options specific to plugin ID, if updated
+- `--from-file` - `string` - load connection spec from file
+- `--raw` - `boolean` - output raw JSON
+
+Example:
+
+```
+morgue workflows connection update \
+  --name changedName \
+  --options.authorizationOptions.type basic \
+  --options.authorizationOptions.username user \
+  --options.authorizationOptions.password changedPassword \
+  10
+```
+
+#### Delete a connection
+
+```
+morgue workflows connection delete [options] <connection id>
+```
+
+Options:
+
+- `--raw` - `boolean` - output raw JSON
+
+Example:
+
+```
+morgue workflows connection delete 10
+```
+
+### Managing integrations
+
+Managing integrations requires an universe and a project to be specified.
+If the universe is not set via config or login, specify it by `--universe`.
+Specify the project using `--project`.
+
+#### List integrations
+
+```
+morgue workflows integration list [options]
+```
+
+Options:
+
+- `--raw` - `boolean` - output raw JSON
+
+Example:
+
+```
+morgue workflows integration list --project myProject --raw
+```
+
+#### Get one integration
+
+```
+morgue workflows integration get <integration id>
+```
+
+Options:
+
+- `--raw` - `boolean` - output raw JSON
+
+Example:
+
+```
+morgue workflows integration get --project myProject 20
+```
+
+#### Create a integration
+
+```
+morgue workflows integration create <options>
+```
+
+By using `--from-file`, you can load integration spec from file.
+Arguments provided by CLI will override the file spec, but they may not be required anymore.
+
+Options:
+
+- `--name` - `string` - integration name, required
+- `--plugin` - `string` plugin ID, required
+- `--options` - `object` - integration options specific to plugin ID, required
+- `--state` - `enabled|disabled|stopped` - integration state, optional
+- `--synchronize-issues` - `boolean` - whether Backtrace to 3rd party issue synchronization is enabled (only for ticket managing plugins), optional
+- `--synchronize-issues-on-add` - `boolean` - whether Backtrace will synchronize issues from 3rd party on adding them from link (only for ticket managing plugins), optional
+- `--connection` - `int` - connection ID to use by the integration, optional (some plugins require a connection for integration)
+- `--from-file` - `string` - load integration spec from file
+- `--raw` - `boolean` - output raw JSON
+
+Example:
+
+```
+morgue workflows integration create \
+  --project myProject \
+  --name myIntegration \
+  --plugin jira \
+  --options.projectId 10017 \
+  --options.displaySettings.attributeList attr1 \
+  --options.displaySettings.attributeList attr2 \
+  --connection 10
+```
+
+#### Update a integration
+
+```
+morgue workflows integration update <options> <integration id>
+```
+
+By using `--from-file`, you can load integration spec from file.
+Arguments provided by CLI will override the file spec, integrationy be not required anymore.
+
+Options:
+
+- `--options` - `object` - partial integration options specific to plugin ID, if updated
+- `--state` - `enabled|disabled|stopped` - integration state, if updated
+- `--synchronize-issues` - `boolean` - whether Backtrace to 3rd party issue synchronization is enabled (only for ticket managing plugins), if updated
+- `--synchronize-issues-on-add` - `boolean` - whether Backtrace will synchronize issues from 3rd party on adding them from link (only for ticket managing plugins), if updated
+- `--connection` - `int` - connection ID to use by the integration, if updated
+- `--from-file` - `string` - load integration spec from file
+- `--raw` - `boolean` - output raw JSON
+
+Example:
+
+```
+morgue workflows integration update \
+  --project myProject \
+  --options.projectId 10020 \
+  20
+```
+
+#### Delete a integration
+
+```
+morgue workflows integration delete [options] <integration id>
+```
+
+Options:
+
+- `--raw` - `boolean` - output raw JSON
+
+Example:
+
+```
+morgue workflows integration delete 20
+```
+
+### Managing alerts
+
+Managing alerts requires an universe and a project to be specified.
+If the universe is not set via config or login, specify it by `--universe`.
+Specify the project using `--project`.
+
+#### List alerts
+
+```
+morgue workflows alert list [options]
+```
+
+Options:
+
+- `--raw` - `boolean` - output raw JSON
+
+Example:
+
+```
+morgue workflows alert list --project myProject --raw
+```
+
+#### Get one alert
+
+```
+morgue workflows alert get <alert id>
+```
+
+Options:
+
+- `--raw` - `boolean` - output raw JSON
+
+Example:
+
+```
+morgue workflows alert get --project myProject 30
+```
+
+#### Create an alert
+
+```
+morgue workflows alert create <options>
+```
+
+By using `--from-file`, you can load alert spec from file.
+Arguments provided by CLI will override the file spec, but they may not be required anymore.
+
+Options:
+
+- `--name` - `string` - alert name, required
+- `--condition` - `object` - alert condition:
+  - `--condition.name` - `string` - can be one of:
+    - `group`,
+    - `trace`,
+    - `usersPerFingerprint`,
+      - `--condition.timeFrame` - `int` - time frame in milliseconds, required
+      - `--condition.value` - `int` - number of users per fingerprint, required
+    - `errorsPerFingerprint`
+      - `--condition.timeFrame` - `int` - time frame in milliseconds, required
+      - `--condition.value` - `int` - number of errors per fingerprint, required
+- `--frequency` - `int` - alert frequency in milliseconds, required
+- `--state` - `enabled|disabled|stopped` - alert state, optional
+- `--filters` - `filter` - alert filter, in the form of `<attribute>,<operator>,[value]`, optional
+- `--integration` - `int` - integration ID executed by alert, optional
+- `--from-file` - `string` - load alert spec from file
+- `--raw` - `boolean` - output raw JSON
+
+Example:
+
+```
+morgue workflows alert create \
+  --project myProject \
+  --name myAlert \
+  --condition.name usersPerFingerprint \
+  --condition.timeFrame 86400000 \
+  --condition.value 10 \
+  --frequency 60000 \
+  --filter attr1,equal,50 \
+  --filter attr2,at-least,40 \
+  --integration 20 \
+  --integration 21 \
+```
+
+#### Update an alert
+
+```
+morgue workflows alert update <options> <alert id>
+```
+
+By using `--from-file`, you can load alert spec from file.
+Arguments provided by CLI will override the file spec, alerty be not required anymore.
+
+Options:
+
+- `--name` - `string` - alert name, if updated
+- `--condition` - `object` - alert condition, if updated:
+  - `--condition.name` - `string` - can be one of:
+    - `group`,
+    - `trace`,
+    - `usersPerFingerprint`,
+      - `--condition.timeFrame` - `int` - time frame in milliseconds, required
+      - `--condition.value` - `int` - number of users per fingerprint, required
+    - `errorsPerFingerprint`
+      - `--condition.timeFrame` - `int` - time frame in milliseconds, required
+      - `--condition.value` - `int` - number of errors per fingerprint, required
+- `--frequency` - `int` - alert frequency in milliseconds, if updated
+- `--state` - `enabled|disabled|stopped` - alert state, if updated
+- `--filters` - `filter` - alert filter, in the form of `<attribute>,<operator>,[value]`, if updated
+- `--integration` - `int` - integration ID executed by alert, if updated
+- `--from-file` - `string` - load alert spec from file
+- `--raw` - `boolean` - output raw JSON
+
+Example:
+
+```
+morgue workflows alert update \
+  --project myProject \
+  --condition.name group \
+  30
+```
+
+#### Delete an alert
+
+```
+morgue workflows alert delete [options] <alert id>
+```
+
+Options:
+
+- `--raw` - `boolean` - output raw JSON
+
+Example:
+
+```
+morgue workflows alert delete --project myProject 30
+```
 
 ## Actions
 
@@ -1556,19 +1987,21 @@ For example:
 morgue actions upload --project myproj myconfig.json
 ```
 
-
 ## Attributes
 
 Morgue can be used to create or delete project index attributes.
 
 The provided commands are as follows:
+
 - `morgue attribute create <project> <name> --description --type --format ` : Create a project index attribute
 - `morgue attribute delete <project> <name> ` : Delete a project index attribute
 
 Formats
+
 - `bitmap`, `uint8`, `uint16`, `uint32`, `uint64`, `uint128`, `uuid`, `dictionary`
 
 Types
+
 - `none`, `commit`, `semver`, `callstack`, `hostname`, `bytes`, `kilobytes`, `gigabytes`, `nanoseconds`, `milliseconds`, `seconds`, `unix_timestamp`, `js_timestamp`, `gps_timestamp`, `memory_address`, `labels`, `sha256`, `uuid`, `ipv4`, `ipv6`
 
 For example:
@@ -1576,6 +2009,7 @@ For example:
 ```
 morgue attribute create myProject myAttribute --description='My Description' --type='uint64' --format='bytes'
 ```
+
 ```
 morgue attribute delete myProject myAttribute
 ```
@@ -1594,6 +2028,7 @@ For example:
 ```
 morgue view create myProject myQueryViewName --queries=queries.json --payload=payload.json
 ```
+
 ```
 morgue view delete myProject myQueryViewName
 ```

--- a/README.md
+++ b/README.md
@@ -1556,11 +1556,11 @@ If it is not set via config or login, specify it with `--universe`.
 morgue workflows connection list [options]
 ```
 
-Options:
+|CLI option|File spec|Type|Description|Required|Default|
+|---|---|---|---|---|---|
+|`raw`||`boolean`|output raw JSON||`false`|
 
-- `--raw` - `boolean` - output raw JSON
-
-Example:
+##### Example
 
 ```
 morgue workflows connection list --raw
@@ -1572,11 +1572,11 @@ morgue workflows connection list --raw
 morgue workflows connection get [options] <connection id>
 ```
 
-Options:
+|CLI option|File spec|Type|Description|Required|Default|
+|---|---|---|---|---|---|
+|`raw`||`boolean`|output raw JSON||`false`|
 
-- `--raw` - `boolean` - output raw JSON
-
-Example:
+##### Example
 
 ```
 morgue workflows connection get 10
@@ -1591,16 +1591,15 @@ morgue workflows connection create <options>
 By using `--from-file`, you can load connection spec from file.
 Arguments provided by CLI will override the file spec, but they may not be required anymore.
 
-Options:
+|CLI option|File spec|Type|Description|Required|Default|
+|---|---|---|---|---|---|
+|`name`|`name`|`string`|connection name|&check;|
+|`plugin`|`pluginId`|`string`|plugin ID|&check;|
+|`options`|`options`|`object`|connection options specific to plugin ID|&check;|
+|`from-file`||`string`|load connection spec from file||
+|`raw`||`boolean`|output raw JSON||`false`|
 
-- `--name` - `string` - connection name, required from CLI or file spec
-- `--plugin` - `string` plugin ID, required from CLI or file spec
-  - `pluginId` - `string` - in file spec
-- `--options` - `object` - connection options specific to plugin ID, required from CLI or file spec
-- `--from-file` - `string` - load connection spec from file
-- `--raw` - `boolean` - output raw JSON
-
-Example:
+##### Example
 
 ```
 morgue workflows connection create \
@@ -1612,7 +1611,7 @@ morgue workflows connection create \
   --options.authorizationOptions.password myPassword
 ```
 
-Example of file spec with above options:
+##### Example of file spec with above options
 
 ```
 morgue workflows connection create --from-file spec.json
@@ -1643,14 +1642,14 @@ morgue workflows connection update <options> <connection id>
 By using `--from-file`, you can load connection spec from file.
 Arguments provided by CLI will override the file spec, but they may not be required anymore.
 
-Options:
+|CLI option|File spec|Type|Description|Required|Default|
+|---|---|---|---|---|---|
+|`name`|`name`|`string`|connection name||
+|`options`|`options`|`object`|connection options specific to plugin ID||
+|`from-file`||`string`|load connection spec from file||
+|`raw`||`boolean`|output raw JSON||`false`|
 
-- `--name` - `string` - connection name, if updated
-- `--options` - `object` - partial connection options specific to plugin ID, if updated
-- `--from-file` - `string` - load connection spec from file
-- `--raw` - `boolean` - output raw JSON
-
-Example:
+##### Example
 
 ```
 morgue workflows connection update \
@@ -1667,11 +1666,11 @@ morgue workflows connection update \
 morgue workflows connection delete [options] <connection id>
 ```
 
-Options:
+|CLI option|File spec|Type|Description|Required|Default|
+|---|---|---|---|---|---|
+|`raw`||`boolean`|output raw JSON||`false`|
 
-- `--raw` - `boolean` - output raw JSON
-
-Example:
+##### Example
 
 ```
 morgue workflows connection delete 10
@@ -1688,11 +1687,11 @@ If universe or project are not set via config or login, specify them with `--uni
 morgue workflows integration list [options]
 ```
 
-Options:
+|CLI option|File spec|Type|Description|Required|Default|
+|---|---|---|---|---|---|
+|`raw`||`boolean`|output raw JSON||`false`|
 
-- `--raw` - `boolean` - output raw JSON
-
-Example:
+##### Example
 
 ```
 morgue workflows integration list --project myProject --raw
@@ -1704,11 +1703,11 @@ morgue workflows integration list --project myProject --raw
 morgue workflows integration get <integration id>
 ```
 
-Options:
+|CLI option|File spec|Type|Description|Required|Default|
+|---|---|---|---|---|---|
+|`raw`||`boolean`|output raw JSON||`false`|
 
-- `--raw` - `boolean` - output raw JSON
-
-Example:
+##### Example
 
 ```
 morgue workflows integration get --project myProject 20
@@ -1723,24 +1722,20 @@ morgue workflows integration create <options>
 By using `--from-file`, you can load integration spec from file.
 Arguments provided by CLI will override the file spec, but they may not be required anymore.
 
-Options:
+|CLI option|File spec|Type|Description|Required|Default|
+|---|---|---|---|---|---|
+|`name`|`watcherName`|`string`|integration name|&check;||
+|`plugin`|`pluginId`|`string`|plugin ID|&check;||
+|`options`|`options`|`object`|integration options specific to plugin ID|&check;||
+|`state`|`state`|`enabled\|disabled\|stopped`|integration state||`enabled`|
+|`synchronize-issues`|`synchronizeIssues`|`boolean`|whether Backtrace to 3rd party issue synchronization is enabled (only for ticket managing plugins)||`false`|
+|`synchronize-issues-on-add`|`synchronizeIssuesOnAdd`|`boolean`|whether Backtrace will synchronize issues from 3rd party on adding them from link (only for ticket managing plugins)||`false`|
+|`connection`|`connectionId`|`int`|connection ID to use by the integration|depends on plugin ID||
+|`from-file`||`string`|load integration spec from file|||
+|`raw`||`boolean`|output raw JSON||`false`|
 
-- `--name` - `string` - integration name, required from CLI or file spec
-  - `watcherName` - `string` - in file spec
-- `--plugin` - `string` plugin ID, required from CLI or file spec
-  - `pluginId` - `string` - in file spec
-- `--options` - `object` - integration options specific to plugin ID, required from CLI or file spec
-- `--state` - `enabled|disabled|stopped` - integration state, optional
-- `--synchronize-issues` - `boolean` - whether Backtrace to 3rd party issue synchronization is enabled (only for ticket managing plugins), optional
-  - `synchronizeIssues` - `boolean` - in file spec
-- `--synchronize-issues-on-add` - `boolean` - whether Backtrace will synchronize issues from 3rd party on adding them from link (only for ticket managing plugins), optional
-  - `synchronizeIssuesOnAdd` - `boolean` - in file spec
-- `--connection` - `int` - connection ID to use by the integration, optional (some plugins require a connection for integration)
-  - `connectionId` - `int` - in file spec
-- `--from-file` - `string` - load integration spec from file
-- `--raw` - `boolean` - output raw JSON
 
-Example:
+##### Example
 
 ```
 morgue workflows integration create \
@@ -1754,7 +1749,7 @@ morgue workflows integration create \
   --options.attributeList attr2
 ```
 
-Example of file spec with above options:
+##### Example of file spec with above options
 
 ```
 morgue workflows integration create --project myProject --from-file spec.json
@@ -1785,20 +1780,17 @@ morgue workflows integration update <options> <integration id>
 By using `--from-file`, you can load integration spec from file.
 Arguments provided by CLI will override the file spec, but they may not be required anymore.
 
-Options:
+|CLI option|File spec|Type|Description|Required|Default|
+|---|---|---|---|---|---|
+|`options`|`options`|`object`|integration options specific to plugin ID|||
+|`state`|`state`|`enabled\|disabled\|stopped`|integration state||`enabled`|
+|`synchronize-issues`|`synchronizeIssues`|`boolean`|whether Backtrace to 3rd party issue synchronization is enabled (only for ticket managing plugins)||`false`|
+|`synchronize-issues-on-add`|`synchronizeIssuesOnAdd`|`boolean`|whether Backtrace will synchronize issues from 3rd party on adding them from link (only for ticket managing plugins)||`false`|
+|`connection`|`connectionId`|`int`|connection ID to use by the integration|||
+|`from-file`||`string`|load integration spec from file|||
+|`raw`||`boolean`|output raw JSON||`false`|
 
-- `--options` - `object` - partial integration options specific to plugin ID, if updated
-- `--state` - `enabled|disabled|stopped` - integration state, if updated
-- `--synchronize-issues` - `boolean` - whether Backtrace to 3rd party issue synchronization is enabled (only for ticket managing plugins), if updated
-  - `synchronizeIssues` - `boolean` - in file spec
-- `--synchronize-issues-on-add` - `boolean` - whether Backtrace will synchronize issues from 3rd party on adding them from link (only for ticket managing plugins), if updated
-  - `synchronizeIssuesOnAdd` - `boolean` - in file spec
-- `--connection` - `int` - connection ID to use by the integration, if updated
-  - `connectionId` - `int` - in file spec
-- `--from-file` - `string` - load integration spec from file
-- `--raw` - `boolean` - output raw JSON
-
-Example:
+##### Example
 
 ```
 morgue workflows integration update \
@@ -1814,11 +1806,11 @@ morgue workflows integration update \
 morgue workflows integration delete [options] <integration id>
 ```
 
-Options:
+|CLI option|File spec|Type|Description|Required|Default|
+|---|---|---|---|---|---|
+|`raw`||`boolean`|output raw JSON||`false`|
 
-- `--raw` - `boolean` - output raw JSON
-
-Example:
+##### Example
 
 ```
 morgue workflows integration delete 20
@@ -1835,11 +1827,11 @@ If universe or project are not set via config or login, specify them with `--uni
 morgue workflows alert list [options]
 ```
 
-Options:
+|CLI option|File spec|Type|Description|Required|Default|
+|---|---|---|---|---|---|
+|`raw`||`boolean`|output raw JSON||`false`|
 
-- `--raw` - `boolean` - output raw JSON
-
-Example:
+##### Example
 
 ```
 morgue workflows alert list --project myProject --raw
@@ -1851,11 +1843,11 @@ morgue workflows alert list --project myProject --raw
 morgue workflows alert get <alert id>
 ```
 
-Options:
+|CLI option|File spec|Type|Description|Required|Default|
+|---|---|---|---|---|---|
+|`raw`||`boolean`|output raw JSON||`false`|
 
-- `--raw` - `boolean` - output raw JSON
-
-Example:
+##### Example
 
 ```
 morgue workflows alert get --project myProject 30
@@ -1870,34 +1862,20 @@ morgue workflows alert create <options>
 By using `--from-file`, you can load alert spec from file.
 Arguments provided by CLI will override the file spec, but they may not be required anymore.
 
-Options:
+|CLI option|File spec|Type|Description|Required|Default|
+|---|---|---|---|---|---|
+|`name`|`name`|`string`|connection name|&check;||
+|`condition.name`|`condition.name`|`string`|[alert condition name](#condition-types)|&check;||
+|`condition.*`|`condition.*`||[alert condition options](#condition-types)|depends on name||
+|`frequency`|`frequency`|`int`|alert frequency in milliseconds|&check;||
+|`execution-delay`|`executionDelay`|`int`|alert execution delay in milliseconds||0|
+|`state`|`state`|`enabled\|disabled\|stopped`|alert state||`enabled`|
+|`filter`|`filters`|`filter[]`|[alert filter](#alert-filters)|||
+|`integration`|`integrations`|`int[]`|integration IDs executed by alert|||
+|`from-file`||`string`|load alert spec from file||
+|`raw`||`boolean`|output raw JSON||`false`|
 
-- `--name` - `string` - alert name, required from CLI or file spec
-- `--condition` - `object` - alert condition, required from CLI or file spec:
-  - `--condition.name` - `string` - can be one of:
-    - `group` - triggers when a new fingerprint (error group) is detected,
-    - `trace` - triggers when a new error is detected,
-    - `usersPerFingerprint` - triggers when number of users affected by a fingerprint is greater than `value` in `timeFrame`,
-      - `--condition.timeFrame` - `int` - time frame in milliseconds, required from CLI or file spec
-      - `--condition.value` - `int` - number of users per fingerprint, required from CLI or file spec
-    - `errorsPerFingerprint` - triggers when number of errors in a fingerprint is greater than `value` in `timeFrame`
-      - `--condition.timeFrame` - `int` - time frame in milliseconds, required from CLI or file spec
-      - `--condition.value` - `int` - number of errors per fingerprint, required from CLI or file spec
-- `--frequency` - `int` - alert frequency in milliseconds, required from CLI or file spec
-- `--execution-delay` - `int` - alert execution delay in milliseconds, required from CLI or file spec
-  - `executionDelay` - `int` - in file spec
-- `--state` - `enabled|disabled|stopped` - alert state, optional
-- `--filter` - `filter` - alert filter, in the form of `<attribute>,<operator>,[value]`, optional
-  - `filters` - `filter[]` - in file spec, of which `filter` is an object with keys:
-    - `attribute` - `string` - attribute name,
-    - `filter[0]` - `string` - operator name,
-    - `filter[1]` - `any` - operator value
-- `--integration` - `int` - integration ID executed by alert, optional
-  - `integrations` - `int[]` - in file spec
-- `--from-file` - `string` - load alert spec from file
-- `--raw` - `boolean` - output raw JSON
-
-Example:
+##### Example
 
 ```
 morgue workflows alert create \
@@ -1952,34 +1930,20 @@ morgue workflows alert update <options> <alert id>
 By using `--from-file`, you can load alert spec from file.
 Arguments provided by CLI will override the file spec, but they may not be required anymore.
 
-Options:
+|CLI option|File spec|Type|Description|Required|Default|
+|---|---|---|---|---|---|
+|`name`|`name`|`string`|connection name|||
+|`condition.name`|`condition.name`|`string`|[alert condition name](#condition-types)|||
+|`condition.*`|`condition.*`||[alert condition options](#condition-types)|depends on name||
+|`frequency`|`frequency`|`int`|alert frequency in milliseconds|||
+|`execution-delay`|`executionDelay`|`int`|alert execution delay in milliseconds|||
+|`state`|`state`|`enabled\|disabled\|stopped`|alert state||`enabled`|
+|`filter`|`filters`|`filter[]`|[alert filter](#alert-filters)|||
+|`integration`|`integrations`|`int[]`|integration IDs executed by alert|||
+|`from-file`||`string`|load alert spec from file||
+|`raw`||`boolean`|output raw JSON||`false`|
 
-- `--name` - `string` - alert name, if updated
-- `--condition` - `object` - alert condition, if updated:
-  - `--condition.name` - `string` - can be one of:
-    - `group`,
-    - `trace`,
-    - `usersPerFingerprint`,
-      - `--condition.timeFrame` - `int` - time frame in milliseconds, required
-      - `--condition.value` - `int` - number of users per fingerprint, required
-    - `errorsPerFingerprint`
-      - `--condition.timeFrame` - `int` - time frame in milliseconds, required
-      - `--condition.value` - `int` - number of errors per fingerprint, required
-- `--frequency` - `int` - alert frequency in milliseconds, if updated
-- `--execution-delay` - `int` - alert execution delay in milliseconds, if updated
-  - `executionDelay` - `int` - in file spec
-- `--state` - `enabled|disabled|stopped` - alert state, if updated
-- `--filter` - `filter` - alert filter, in the form of `<attribute>,<operator>,[value]`, if updated
-  - `filters` - `filter[]` - in file spec, of which `filter` is an object with keys:
-    - `attribute` - `string` - attribute name,
-    - `filter[0]` - `string` - operator name,
-    - `filter[1]` - `any` - operator value
-- `--integration` - `int` - integration ID executed by alert, if updated
-  - `integrations` - `int[]` - in file spec
-- `--from-file` - `string` - load alert spec from file
-- `--raw` - `boolean` - output raw JSON
-
-Example:
+##### Example
 
 ```
 morgue workflows alert update \
@@ -1994,15 +1958,43 @@ morgue workflows alert update \
 morgue workflows alert delete [options] <alert id>
 ```
 
-Options:
+|CLI option|File spec|Type|Description|Required|Default|
+|---|---|---|---|---|---|
+|`raw`||`boolean`|output raw JSON||`false`|
 
-- `--raw` - `boolean` - output raw JSON
-
-Example:
+##### Example
 
 ```
 morgue workflows alert delete --project myProject 30
 ```
+
+#### Alert options
+
+##### Condition types
+
+|Condition name|CLI option|File spec|Type|Description|Required|
+|---|---|---|---|---|---|
+|`group`|\<no options\>|||triggers when a new fingerprint (error group) is detected||
+|`trace`|\<no options\>|||triggers when a new error is detected||
+|`usersPerFingerprint`||||triggers when number of users affected by a fingerprint is greater than `value` in `timeFrame`||
+||`condition.timeFrame`|`condition.timeFrame`|`int`|time frame in milliseconds|&check;|
+||`condition.value`|`condition.value`|`int`|number of users per fingerprint|&check;|
+|`errorsPerFingerprint`||||triggers when number of users affected by a fingerprint is greater than `value` in `timeFrame`||
+||`condition.timeFrame`|`condition.timeFrame`|`int`|time frame in milliseconds|&check;|
+||`condition.value`|`condition.value`|`int`|number of errors per fingerprint|&check;|
+
+##### Alert filters
+
+Alert filters follow the same principle as [filters](#filters), but do not support flags.
+
+In file spec you can define alerts as object array of following keys:
+
+|Key|Type|Description|Required|
+|---|---|---|---|
+|`attribute`|`string`|attribute name|&check;|
+|`filter`|`[string, any]`|filter operator and value|&check;|
+|`filter[0]`|`string`|operator name|&check;|
+|`filter[1]`|`any`|operator value|&check;|
 
 ## Actions
 

--- a/README.md
+++ b/README.md
@@ -1833,6 +1833,7 @@ Options:
       - `--condition.timeFrame` - `int` - time frame in milliseconds, required
       - `--condition.value` - `int` - number of errors per fingerprint, required
 - `--frequency` - `int` - alert frequency in milliseconds, required
+- `--execution-delay` - `int` - alert execution delay in milliseconds, required
 - `--state` - `enabled|disabled|stopped` - alert state, optional
 - `--filters` - `filter` - alert filter, in the form of `<attribute>,<operator>,[value]`, optional
 - `--integration` - `int` - integration ID executed by alert, optional
@@ -1878,6 +1879,7 @@ Options:
       - `--condition.timeFrame` - `int` - time frame in milliseconds, required
       - `--condition.value` - `int` - number of errors per fingerprint, required
 - `--frequency` - `int` - alert frequency in milliseconds, if updated
+- `--execution-delay` - `int` - alert execution delay in milliseconds, if updated
 - `--state` - `enabled|disabled|stopped` - alert state, if updated
 - `--filters` - `filter` - alert filter, in the form of `<attribute>,<operator>,[value]`, if updated
 - `--integration` - `int` - integration ID executed by alert, if updated

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ npm install backtrace-morgue -g
 ```
 
 If you working from the repository, then instead use the following command.
-
 ```
 npm install -g
 ```
@@ -103,9 +102,9 @@ to standard output. Optionally, output the file to disk.
 
 The following options are available:
 
-| Option            | Description                                          |
-| ----------------- | ---------------------------------------------------- |
-| `--resource=name` | Fetch the specified resource rather than the object. |
+| Option        | Description |
+|---------------|-------------|
+| `--resource=name`| Fetch the specified resource rather than the object. |
 
 ### put
 
@@ -115,13 +114,13 @@ Usage: morgue put <[<universe>/]project> <file> <--format=btt|minidump|json|symb
 
 Uploads object file to the Backtrace object store. User has the following options
 
-| Option                             | Description                                     |
-| ---------------------------------- | ----------------------------------------------- | --------------------------- |
-| `--compression=gzip                | deflate`                                        | uploaded file is compressed |
-| `--kv=key1:value1,key2:value2,...` | upload key-values                               |
-| `--form_data`                      | upload file by multipart/form-data post request |
+| Option        | Description |
+|---------------|-------------|
+| `--compression=gzip|deflate`| uploaded file is compressed |
+| `--kv=key1:value1,key2:value2,...`| upload key-values |
+| `--form_data`| upload file by multipart/form-data post request |
 
-### set
+### set 
 
 ```
 Usage: morgue set <[universe/]project> <query> <key>=<value>
@@ -217,42 +216,41 @@ first `<n>` rows.
 
 #### Selection
 
-Selection can be done with two options, `--select=<attribute>` and
-`--select-wildcard=<physical|derived|virtual>`.
+Selection can be done with two options, `--select=<attribute>` and 
+`--select-wildcard=<physical|derived|virtual>`. 
 
 `--select` allows to select particular attributes, while `--select-wildcard` selects
 all attributes that match the option.
 
 Wildcards can be one of:
-
-- `physical` - selects all attributes that are physically stored in objects,
-- `derived` - selects all derived attributes, such as `first_seen` or `original`,
-- `virtual` - selects all virtual (join) attributes.
+* `physical` - selects all attributes that are physically stored in objects,
+* `derived` - selects all derived attributes, such as `first_seen` or `original`,
+* `virtual` - selects all virtual (join) attributes.
 
 #### Aggregations
 
 Aggregation is expressed through a myriad of command-line options that express
 different aggregation operations. Options are of form `--<option>=<attribute>`.
 
-The `*` factor is used when aggregations are performed when no factor is
+The ``*`` factor is used when aggregations are performed when no factor is
 specified or if an object does not have a valid value associated with the
 factor.
 
-| Option           | Description                                                               |
-| ---------------- | ------------------------------------------------------------------------- |
-| `--age`          | Specify a relative timestamp to now. `1h` ago, or `1d` ago.               |
+| Option           | Description |
+|------------------|-------------|
+| `--age`          | Specify a relative timestamp to now. `1h` ago, or `1d` ago. |
 | `--time`         | Specify a range using [Chrono](https://github.com/wanasit/chrono#readme). |
-| `--unique`       | provide a count of distinct values                                        |
-| `--histogram`    | provide all distinct values                                               |
-| `--distribution` | provide a truncated histogram                                             |
-| `--mean`         | calculate the mean of a column                                            |
-| `--sum`          | sum all values                                                            |
-| `--range`        | provide the minimum and maximum values                                    |
-| `--count`        | count all non-null values                                                 |
-| `--bin`          | provide a linear histogram of values                                      |
-| `--head`         | provide the first value in a factor                                       |
-| `--tail`         | provide the last value in a factor                                        |
-| `--object`       | provide the maximum object identifier of a column                         |
+| `--unique`       | provide a count of distinct values |
+| `--histogram`    | provide all distinct values |
+| `--distribution` | provide a truncated histogram |
+| `--mean`    	   | calculate the mean of a column |
+| `--sum`          | sum all values |
+| `--range`        | provide the minimum and maximum values |
+| `--count`        | count all non-null values |
+| `--bin`          | provide a linear histogram of values |
+| `--head`         | provide the first value in a factor |
+| `--tail`         | provide the last value in a factor |
+| `--object`       | provide the maximum object identifier of a column |
 
 #### Sorting
 
@@ -265,10 +263,10 @@ syntax is `[-](<column>|<fold_term>)`.
   effective for selection type query, i.e. when using the `--select` and/or `--select-wildcard` option.
 - The `<fold_term>` is an expression pointing to a fold operation. The
   expression language for fold operation is one of the following literal:
-  - `;group`: sort by the group key itself.
-  - `;count`: sort by the group count (number of crashes).
-  - `column;idx`: where `column` is a string referencing a column in the fold
-    dictionary and `idx` is an indice in the array. See examples .
+    - `;group`: sort by the group key itself.
+    - `;count`: sort by the group count (number of crashes).
+    - `column;idx`: where `column` is a string referencing a column in the fold
+      dictionary and `idx` is an indice in the array. See examples .
 
 Multiple sort terms can be provided to break ties in case the previous
 referenced sort term has ties.
@@ -287,7 +285,7 @@ Forms:
 --quantize-uint output_column,input_column,size,offset
 ```
 
-Computes `( column + offset ) / size - offset` using integer math. Used for
+Computes `( column + offset ) / size - offset` using integer math.  Used for
 data alignment and rounding.
 
 Size and offset may be integers or time units: `3600` and `1h` are both valid.
@@ -435,8 +433,8 @@ Object IDs must be specified; they can be found in `morgue list` output.
 The object ID printed in the example above is `9d33`.
 
 By default, this command (as of 2019-02-26) requests physical-only deletion,
-which retains only indexing. The previous `--physical-only` argument is a
-no-op. The following options affect this behavior:
+which retains only indexing.  The previous `--physical-only` argument is a
+no-op.  The following options affect this behavior:
 `--all`: Delete all related data, including indexing.
 `--crdb-only`: Only delete the indexed data; requires physically deleted objects.
 
@@ -473,6 +471,8 @@ http://www.brendangregg.com/flamegraphs.html.
 Use `--unique` to only sample unique crashes. Use `--reverse` to begin sampling
 from leaf functions.
 
+
+
 ### symbold
 
 Manage Backtrace symbold service
@@ -481,82 +481,63 @@ Manage Backtrace symbold service
 Usage: morgue symbold <symbolserver | whitelist | blacklist | skiplist | status> <action>
 ```
 
+
 #### status
-
 Return Symbold service status for <[universe]/project>
-
 ```
 Usage: morgue symbold status <[universe]/project>
 ```
 
 #### symbolserver
-
 Symbol server allows you to manage symbol servers used by symbold
 
 #### list
-
 List Symbold symbol server assigned to <[universe]/project>
-
 ```
 Usage: morgue symbold symbolserver list <[universe]/project>
 ```
-
 Example:
-
 ```
 $ morgue symbold symbolserver list backtrace
 ```
 
 #### details
-
 Retruns detailed information about symbol server
-
 ```
 Usage: morgue symbold symbolserver details [symbolserverid]
 ```
 
 Example:
-
 ```
 $ morgue symbold symbolserver details 1
-```
-
+``` 
 Command line above will return detailed information for symbol server with id 1
 
 #### logs
-
 Returns symbol server logs. You can use page and take arguments to get more/less logs.
-
 ```
 Usage: morgue symbold symbolserver logs [symbolserverid]
 ```
 
 Example:
-
 ```
 $ morgue symbold symbolserver logs 1 --take=100 --page=0
 ```
-
 Command above will return first 100 logs from page 0
 
 #### filter logs
-
 Returns filtered symbol server logs. By using this command you can filter all logs that match your criteria.
-
 ```
 Usage morgue symbold symbolserver logs [symbolserverid] filter [filter]
 ```
 
 Example:
-
 ```
 morgue.js symbold symbolserver logs 5 filter a --take=100 --page=1
 ```
-
 #### add
-
 ```
-Usage: morgue symbold symbolserver add <[universe]/project> [symbolserverurl]
+Usage: morgue symbold symbolserver add <[universe]/project> [symbolserverurl] 
   <--name=...>
   <--concurrentdownload=...>
   <--retrylimit=...>
@@ -576,38 +557,35 @@ Usage: morgue symbold symbolserver add <[universe]/project> [symbolserverurl]
   <--proxy.username=...>
   <--proxy.password=...>
 ```
-
 Add new symbol server to symbold service. Available options:
+* `name` - symbol server name,
+* `concurrentdownload` - maximum number of concurrent download that symbolmd will do at the same time,
+* `timeout` - download timeout
+* `whitelist` - determine if symbol server should use whitelist or not,
+* `retain` - determine if symbold should retain original symbols
+* `servercredentials` - symbol server auth options
+* `servercredentials.username` - symbol server auth user name,
+* `servercredentials.password` - symbol server auth password,
+* `aws.accesskey` - AWS S3 access key
+* `aws.secret` - AWS S3 secret
+* `aws.bucketname` - AWS S3 bucket name
+* `aws.lowerfile` - determine if symbold should use lower case symbol name
+* `aws.lowerid` - - determine if symbold should use lower case debug id
+* `aws.usepdb` - determine a way to generate url to S3 symbols
+* `proxy.host` - proxy host
+* `proxy.port` - proxy port
+* `proxy.username` - proxy username
+* `proxy.password` - proxy password
 
-- `name` - symbol server name,
-- `concurrentdownload` - maximum number of concurrent download that symbolmd will do at the same time,
-- `timeout` - download timeout
-- `whitelist` - determine if symbol server should use whitelist or not,
-- `retain` - determine if symbold should retain original symbols
-- `servercredentials` - symbol server auth options
-- `servercredentials.username` - symbol server auth user name,
-- `servercredentials.password` - symbol server auth password,
-- `aws.accesskey` - AWS S3 access key
-- `aws.secret` - AWS S3 secret
-- `aws.bucketname` - AWS S3 bucket name
-- `aws.lowerfile` - determine if symbold should use lower case symbol name
-- `aws.lowerid` - - determine if symbold should use lower case debug id
-- `aws.usepdb` - determine a way to generate url to S3 symbols
-- `proxy.host` - proxy host
-- `proxy.port` - proxy port
-- `proxy.username` - proxy username
-- `proxy.password` - proxy password
 
 Example:
-
 ```
 $ morgue symbold symbolserver backtrace https://symbol.server.com --name=name --timeout=400
 ```
 
 #### update
-
 ```
-Usage: morgue symbold symbolserver update [symbolserverid]
+Usage: morgue symbold symbolserver update [symbolserverid] 
   <--url=...>
   <--name=...>
   <--concurrentdownload=...>
@@ -628,142 +606,111 @@ Usage: morgue symbold symbolserver update [symbolserverid]
   <--argv.proxy.username=...>
   <--argv.proxy.password=...>
 ```
-
-Update symbol server with id [symbolServerId]. If aws, proxy and servercredentials data doesn't exists symbold will ignore update server credentials. If any of them exists, symbold will try to update all properties.
+Update  symbol server with id [symbolServerId]. If aws, proxy and servercredentials data doesn't exists symbold will ignore update server credentials. If any of them exists, symbold will try to update all properties.
 Example:
-
 ```
 $ morgue symbold symbolserver update 1 --url="http://new.symbol.server.url"
 ```
 
 #### disable
-
+Disable symbol server. Symbold won't use disabled symbol server. 
+```
+Usage: morgue symbold symbolserver disable [symbolserverid] 
+```
 Disable symbol server. Symbold won't use disabled symbol server.
 
-```
-Usage: morgue symbold symbolserver disable [symbolserverid]
-```
-
-Disable symbol server. Symbold won't use disabled symbol server.
-
-#### enable
-
-Enable symbol server. Symbold won't use disabled symbol server.
-
+#### enable 
+Enable symbol server. Symbold won't use disabled symbol server. 
 ```
 Usage: morgue symbold symbolserver enable [symbolserverid]
 ```
-
 Enable symbol server.
 
 #### whitelist/blacklist/skiplist
 
-##### add
-
+##### add 
 Add new element to whitelist/blacklist
-
 ```
 Usage: morgue symbold [whitelist|blacklist] [--name=...]
 ```
-
 Add new element to blacklist/whitelist
 
-##### remove
 
+##### remove 
 Remove element from skiplist/blacklist/skiplist by using element id
-
 ```
 Usage : morgue symbold [whitelist|blacklist|skiplist] [--itemid=...]
 ```
 
-##### list
-
+##### list 
 List <--take> elements from [whitelist|blacklist|skiplist] from <--page> page
-
 ```
 Usage: morgue symbold [whitelist|blacklist|skiplist] <--page=...> <--take=...>
 ```
 
+
 #### skiplist [only]
 
-##### find
-
+##### find 
 Find elements in skiplist
-
 ```
 morgue symbold skiplist find [symbolServerId] [filter] <--page=...> <--take=...>
 ```
-
-Usage:
-
+Usage: 
 ```
-$ morgue symbold skiplist find 5 sample.dll
+$ morgue symbold skiplist find 5 sample.dll 
 ```
 
-##### remove all
 
+##### remove all 
 Remove all elements in skiplist
-
 ```
 morgue symbold skiplist remove all [symbolServerId]
 ```
-
-Usage:
-
+Usage: 
 ```
 $ morgue symbold skiplist remove all 5
 ```
 
 ##### remove by filter
-
-Remove all elements in skiplist that match filter criteria
-
+Remove all elements in skiplist that match filter criteria  
 ```
 morgue symbold skiplist remove all [symbolServerId]
 ```
-
-Usage:
-
+Usage: 
 ```
 $ morgue symbold skiplist remove all 5
 ```
 
-#### queue
 
+#### queue
 Symbold queue commands
 
-##### list
-
+##### list 
 returns all events in symbold queue
-
 ```
-Usage: morgue symbold queue list
+Usage: morgue symbold queue list 
 ```
 
 ##### Add
-
-Add event on the top of symbold queue
-
+Add event on the top of symbold queue 
 ```
-morgue symbold queue <add | create> <universe/project> <missingSymbol> <objectId>
+morgue symbold queue <add | create> <universe/project> <missingSymbol> <objectId> 
 ```
-
 Usage:
-
 ```
 $ morgue symbold queue add universe/project "a.pdb,123" 123
 ```
 
 ##### Size
-
 Returns queue size - how many reports symbold still have to reprocess
 
 ```
 Usage: morgue symbold queue size
 ```
 
-##### Symbold
 
+##### Symbold
 List all missing symbols from symbold events
 
 ```
@@ -793,7 +740,6 @@ Usage: morgue report <project> create
 ```
 
 Example:
-
 ```
 $ morgue report MyProject create --rcpt=null@backtrace.io
     --rcpt=list@backtrace.io --filter=environment,equal,prod
@@ -851,11 +797,11 @@ Options for reprocess:
   --last=N         Specify the last object ID (default: most recent known)
 ```
 
-Reprocess the project's objects. This command can be used to re-execute
+Reprocess the project's objects.  This command can be used to re-execute
 indexing, fingerprinting, and symbolification (where needed).
 
 If a set of objects (or query) is specified, any values for `--first` and
-`--last` are replaced to match the object list. If no query, object list,
+`--last` are replaced to match the object list.  If no query, object list,
 or range is provided, all objects in the project are reprocessed.
 
 ### retention
@@ -926,7 +872,6 @@ $
 ```
 
 Set instance policy to compress after 7 days:
-
 ```
 $ morgue retention set --type=instance --max-age=7d --compress
 success
@@ -957,9 +902,9 @@ Project is a required flag if fingerprint is specified.
 #### Configuring Sampling (Coronerd 1.50+)
 
 In Coronerd 1.50, it became possible to configure sampling on a per-project
-basis as well as using `coronerd.conf`. This is done with the
+basis as well as using `coronerd.conf`.  This is done with the
 `morgue sampling configure` command. Configurations specified on projects
-override the `coronerd.conf` settings. For example:
+override the `coronerd.conf` settings.  For example:
 
 ```
 morgue sampling configure --project myproject \
@@ -988,7 +933,7 @@ The available options are as follows:
 - `--backoff count,interval`: Specify a backoff entry. This option must be
   specified at least once, multiple instances must be specified in
   increasing order of interval, and the first backoff must always have a `0`
-  interval. `interval` supports time units: `1d`, etc.
+  interval.  `interval` supports time units: `1d`, etc.
 - `--buckets`: The maximum number of sampling buckets to allow. Optional,
   default 512.
 - `--process-whitelisted true|false`: whether to sample objects with
@@ -1060,11 +1005,10 @@ Usage: morgue token create --project=<project> --capability=<capability>
 ```
 
 Capability can be any of:
-
-- symbol:post - Enable symbol uploads with the specified API token.
-- error:post - Enable error and dump submission with the specified API token.
-- query:post - Enable queries to be issued using the specified token.
-- sync:post - Allow for slower but more verbose submission.
+ * symbol:post - Enable symbol uploads with the specified API token.
+ * error:post  - Enable error and dump submission with the specified API token.
+ * query:post  - Enable queries to be issued using the specified token.
+ * sync:post   - Allow for slower but more verbose submission.
 
 Multiple capabilities can be specified by using `--capability` multiple times
 or using a comma-separated list.
@@ -1097,16 +1041,15 @@ Usage: morgue user reset [--universe=...] [--user=...] [--password=...] [--role=
 ### users
 
 Add signup domain whitelist.
-
 ```
 Usage: morgue users add-signup-whitelist [--universe=...] [--domain=...] [--role=...] [--method=...]
 ```
 
 List users that are not associated with a team.
-
 ```
 Usage: morgue users list-teamless-users
 ```
+
 
 ### tenant
 
@@ -1180,14 +1123,14 @@ to their callstack attribute.
 Usage: morgue similarity <[universe]/project> [filter expression]
     [--threshold=N]     The minimum length of the callstack for groups to
                         consider for similarity analysis.
-    [--truncate=N]      Shorten the callstack before comparing.
+    [--truncate=N]      Shorten the callstack before comparing.   
     [--intersection=N]  The minimum number of common symbols between
                         two groups.
     [--distance=N]      The maximum acceptable edit distance between
                         two groups.
     [--fingerprint=N]   A fingerprint to compute similarity to. If omitted,
-                        a project summary will be computed instead.
-    [--json]            Return the JSON result of the similarity request.
+                        a project summary will be computed instead. 
+    [--json]            Return the JSON result of the similarity request.                
 ```
 
 ### invite
@@ -1290,7 +1233,6 @@ $ morgue callstack evaluate project file.json
 ## Access control
 
 Allows controlling coroner's access control mechanisms
-
 ```
 Usage:
 morgue access <action> [params...]
@@ -1314,15 +1256,12 @@ action project:
 ```
 
 ### action team
-
 Allows manipulation of teams - creation, removal, listing, displaying details and adding/removing users to teams.
 
 ### action project
-
 Allows manipulation of projects in terms of access control - display details or add/remove user or team.
 
 Possible roles:
-
 - admin
 - member
 - guest
@@ -1334,13 +1273,13 @@ the highest privileges afforded by any of those access routes.
 ## Stability Score and Storing Metrics Data
 
 Morgue offers the ability to configure metrics for importing metrics data with
-`metrics-importer` or custom API integrations. This can be used from CI to
-provision new metrics against a metric group and begin shipping data. At the
+`metrics-importer` or custom API integrations.  This can be used from CI to
+provision new metrics against a metric group and begin shipping data.  At the
 moment, Morgue assumes setup and most common operations on entities for
 metrics importing are carried out through the frontend and only offers the
 subset of functionality necessary for automation from CI.
 
-Generally, the typical flow occurs in two stages. First:
+Generally, the typical flow occurs in two stages.  First:
 
 ```
 morgue stability create-metric --project myproj --metric-group stability \
@@ -1382,12 +1321,12 @@ This will provision a metric on the Coronerd side that can be fed via
 timeseries submission endpoints.
 
 Attribute values are of the form `--attribute name,value`.
-An attribute value must be specified for every non-defaulted attribute
+An attribute value must be specified for every non-defaulted attribute 
 on the group.
 
 ### Controlling `metrics-importer`
 
-It is possible to use Morgue to configure importers for stability score. This
+It is possible to use Morgue to configure importers for stability score.  This
 requires Coronerd >= 1.48 and a deployed backtrace-metrics-importer.
 Usage:
 
@@ -1398,7 +1337,7 @@ morgue metrics-importer <command>...
 #### `source check-query`
 
 Determines if a query is valid by running it against a source as if it had been
-used with an importer and displays diagnostic information. For example:
+used with an importer and displays diagnostic information.  For example:
 
 ```
 morgue metrics-importer source check-query --source my-source-uuid \
@@ -1408,17 +1347,17 @@ morgue metrics-importer source check-query --source my-source-uuid \
 
 #### `importer create`
 
-Creates an importer. Takes the following options:
+Creates an importer.  Takes the following options:
 
-| Option         | Description                                                      |
-| -------------- | ---------------------------------------------------------------- |
-| --project      | The project of the source.                                       |
-| --source       | UUID of the source to associate the importer with.               |
-| --name         | The name of the importer to create.                              |
-| --start-at     | The time to start scraping from in RFC3339 format.               |
-| --metric       | The name of the metric to associate data with in Coronerd.       |
-| --metric-group | The name of the metric group to associate data with in Coronerd. |
-| --delay        | The delay of the importer. Defaults to 60.                       |
+Option         | Description
+-------------- | --------------------------------------------------------------
+--project      | The project of the source.
+--source       | UUID of the source to associate the importer with.
+--name         | The name of the importer to create.
+--start-at     |  The time to start scraping from in RFC3339 format.
+--metric       | The name of the metric to associate data with in Coronerd.
+--metric-group | The name of the metric group to associate data with in Coronerd.
+--delay        | The delay of the importer. Defaults to 60.
 
 For example:
 
@@ -1434,12 +1373,12 @@ morgue metrics-importer importer create \
 --delay 120
 ```
 
-Note that `--query` depends on the source type. See the stability score
+Note that `--query` depends on the source type.  See the stability score
 documentation for details.
 
 #### `logs`
 
-Displays logs. Usage:
+Displays logs.  Usage:
 
 ```
 morgue metrics-importer logs --project myproj --source-id my-source-id
@@ -1448,6 +1387,7 @@ morgue metrics-importer logs --project myproj --importer-id my-importer-id
 
 You can pass `--limit` to limit the number of returned messages.
 By default `--limit` is 100.
+
 
 # Alerts
 
@@ -1465,7 +1405,8 @@ Details follow.
 
 Let's say that you want to create an alert which will fire if there ware more
 than 5 errors in the last minute, and will mark groups as critical if more than
-10 errors occur. To do so:
+10 errors occur.  To do so:
+
 
 Start by creating a target if you don't already have one:
 
@@ -1494,7 +1435,7 @@ morgue  alerts alert create --name test \
 
 All alerting subcommands which refer to an object support identifying objects
 through either their name or ID, and take two mutually exclusive parameters:
-`--name` or `--id`. For instance:
+`--name` or `--id`.  For instance:
 
 ```
 morgue alerts alert get --name myalert
@@ -1519,7 +1460,7 @@ morgue alerts target update --name my-target [--rename new-name]
   [--workflow-name new-workflow]
 ```
 
-Create and manage targets. Note that since Morgue allows identifying objects
+Create and manage targets.  Note that since Morgue allows identifying objects
 through `--name`, it is necessary to use `--rename` to change the name.
 
 ## Alert Creation And Update
@@ -1529,26 +1470,25 @@ morgue alerts alert create <args>
 morgue alert alerts update <args>
 ```
 
-Create and update alerts. Create requires all of the following
+Create and update alerts.  Create requires all of the following
 parameters which don't have defaults, while update patches the object with
 those specified and has no required parameters beyond identifying the alert to
-apply to. Parameters are as follows (see below for query and trigger
+apply to.  Parameters are as follows (see below for query and trigger
 specification):
 
 -`--name`: For create, the name of the new alert. For update, identify the
-alert to modify by name.
-
+  alert to modify by name.
 - `--enabled true|false`: whether the alert is enabled. Defaults to `true` for
   create.
-  -- `--query-period = <timespec>`: the query period. Supports time specifications
+-- `--query-period = <timespec>`: the query period. Supports time specifications
   in the same fashion as `morgue list --age`: `5m`, `1h`, etc.
   Note that the service puts a lower bound of 1 minute on this value.
 - `--min-notification-interval`: the minimum notification interval, which
   controls the maximum interval at which an alert can send notifications to an
   integration.
 - `--mute-until`: Unix timestamp. The alert will be silenced until after this
-  timestamp. The timestamp must currently be specified as integer seconds
-  since the Unix epoch. For create, defaults to 0, which doesn't mute
+  timestamp.  The timestamp must currently be specified as integer seconds
+  since the Unix epoch.  For create, defaults to 0, which doesn't mute
   the alert.
 - `--target-id`: Specified zero or more times to indicate the targets to which
   to send the alert. Unioned with `--target-names`.
@@ -1567,8 +1507,8 @@ Update also supports the following arguments:
 The create and update subcommands allow specifying the query using the same
 arguments as the `morgue list` command, save that `--age` is ignored,
 `--select` or `--select-wildcard` isn't allowed, and any implicit time filtering
-that Morgue would otherwise apply is disabled. Since empty CLI arguments are
-a valid query, update additionally requires supplying `--replace-query` to indicate
+that Morgue would otherwise apply is disabled.  Since empty CLI arguments are 
+a valid query, update additionally requires supplying `--replace-query` to indicate 
 that the query is being replaced.
 
 The alerts service itself can only function properly with aggregation queries
@@ -1585,13 +1525,13 @@ The `--trigger` option has the form:
 
 Alerts identifies aggregates to trigger on by their column name, and the index
 in the same fashion as `--sort` on list, though `;count` is unsupported (for
-that, ad a `--count column` aggregate). The components of a trigger are as
+that, ad a `--count column` aggregate).  The components of a trigger are as
 follows:
 
 - `column`: The column the trigger is for, for example `fingerprint`.
 - `index`: The index of the aggregate for the specified column.
 - `comparison`: Either `ge` or `le`. Controls whether the thresholds are `>==>
-or `<=`the query's returned values.  Most triggers will use`ge`.
+  or `<=` the query's returned values.  Most triggers will use `ge`.
 - `warning`: the warning threshold for the trigger.
 - `critical`: The critical threshold for the trigger.
 
@@ -1989,21 +1929,19 @@ For example:
 morgue actions upload --project myproj myconfig.json
 ```
 
+
 ## Attributes
 
 Morgue can be used to create or delete project index attributes.
 
 The provided commands are as follows:
-
 - `morgue attribute create <project> <name> --description --type --format ` : Create a project index attribute
 - `morgue attribute delete <project> <name> ` : Delete a project index attribute
 
 Formats
-
 - `bitmap`, `uint8`, `uint16`, `uint32`, `uint64`, `uint128`, `uuid`, `dictionary`
 
 Types
-
 - `none`, `commit`, `semver`, `callstack`, `hostname`, `bytes`, `kilobytes`, `gigabytes`, `nanoseconds`, `milliseconds`, `seconds`, `unix_timestamp`, `js_timestamp`, `gps_timestamp`, `memory_address`, `labels`, `sha256`, `uuid`, `ipv4`, `ipv6`
 
 For example:
@@ -2011,7 +1949,6 @@ For example:
 ```
 morgue attribute create myProject myAttribute --description='My Description' --type='uint64' --format='bytes'
 ```
-
 ```
 morgue attribute delete myProject myAttribute
 ```
@@ -2030,7 +1967,6 @@ For example:
 ```
 morgue view create myProject myQueryViewName --queries=queries.json --payload=payload.json
 ```
-
 ```
 morgue view delete myProject myQueryViewName
 ```

--- a/README.md
+++ b/README.md
@@ -1779,11 +1779,12 @@ Example:
 morgue workflows integration create \
   --project myProject \
   --name myIntegration \
-  --plugin jira \
-  --options.projectId 10017 \
-  --options.displaySettings.attributeList attr1 \
-  --options.displaySettings.attributeList attr2 \
-  --connection 10
+  --plugin s3export \
+  --options.bucketPath s3://my-bucket \
+  --options.credentials.awsAccessKeyId key \
+  --options.credentials.awsSecretAccessKey secret \
+  --options.attributeList attr1 \
+  --options.attributeList attr2
 ```
 
 #### Update a integration
@@ -1810,7 +1811,8 @@ Example:
 ```
 morgue workflows integration update \
   --project myProject \
-  --options.projectId 10020 \
+  --options.bucketPath s3://new-bucket-path \
+  --options.attributeList attr1 \
   20
 ```
 

--- a/README.md
+++ b/README.md
@@ -1593,9 +1593,10 @@ Arguments provided by CLI will override the file spec, but they may not be requi
 
 Options:
 
-- `--name` - `string` - connection name, required
-- `--plugin` - `string` plugin ID, required
-- `--options` - `object` - connection options specific to plugin ID, required
+- `--name` - `string` - connection name, required from CLI or file spec
+- `--plugin` - `string` plugin ID, required from CLI or file spec
+  - `pluginId` - `string` - in file spec
+- `--options` - `object` - connection options specific to plugin ID, required from CLI or file spec
 - `--from-file` - `string` - load connection spec from file
 - `--raw` - `boolean` - output raw JSON
 
@@ -1609,6 +1610,28 @@ morgue workflows connection create \
   --options.authorizationOptions.type basic \
   --options.authorizationOptions.username user \
   --options.authorizationOptions.password myPassword
+```
+
+Example of file spec with above options:
+
+```
+morgue workflows connection create --from-file spec.json
+```
+
+```json
+// spec.json
+{
+  "name": "myConnection",
+  "pluginId": "jira",
+  "options": {
+    "baseUrl": "https://my-jira.atlassian.net",
+    "authorizationOptions": {
+      "type": "basic",
+      "username": "user",
+      "password": "myPassword"
+    }
+  }
+}
 ```
 
 #### Update a connection
@@ -1703,13 +1726,18 @@ Arguments provided by CLI will override the file spec, but they may not be requi
 
 Options:
 
-- `--name` - `string` - integration name, required
-- `--plugin` - `string` plugin ID, required
-- `--options` - `object` - integration options specific to plugin ID, required
+- `--name` - `string` - integration name, required from CLI or file spec
+  - `watcherName` - `string` - in file spec
+- `--plugin` - `string` plugin ID, required from CLI or file spec
+  - `pluginId` - `string` - in file spec
+- `--options` - `object` - integration options specific to plugin ID, required from CLI or file spec
 - `--state` - `enabled|disabled|stopped` - integration state, optional
 - `--synchronize-issues` - `boolean` - whether Backtrace to 3rd party issue synchronization is enabled (only for ticket managing plugins), optional
+  - `synchronizeIssues` - `boolean` - in file spec
 - `--synchronize-issues-on-add` - `boolean` - whether Backtrace will synchronize issues from 3rd party on adding them from link (only for ticket managing plugins), optional
+  - `synchronizeIssuesOnAdd` - `boolean` - in file spec
 - `--connection` - `int` - connection ID to use by the integration, optional (some plugins require a connection for integration)
+  - `connectionId` - `int` - in file spec
 - `--from-file` - `string` - load integration spec from file
 - `--raw` - `boolean` - output raw JSON
 
@@ -1727,6 +1755,28 @@ morgue workflows integration create \
   --options.attributeList attr2
 ```
 
+Example of file spec with above options:
+
+```
+morgue workflows integration create --project myProject --from-file spec.json
+```
+
+```json
+// spec.json
+{
+  "watcherName": "myIntegration",
+  "pluginId": "s3Export",
+  "options": {
+    "bucketPath": "s3://my-bucket",
+    "credentials": {
+      "awsAccessKeyId": "key",
+      "awsSecretAccessKey": "secret"
+    },
+    "attributeList": ["attr1", "attr2"]
+  }
+}
+```
+
 #### Update a integration
 
 ```
@@ -1741,8 +1791,11 @@ Options:
 - `--options` - `object` - partial integration options specific to plugin ID, if updated
 - `--state` - `enabled|disabled|stopped` - integration state, if updated
 - `--synchronize-issues` - `boolean` - whether Backtrace to 3rd party issue synchronization is enabled (only for ticket managing plugins), if updated
+  - `synchronizeIssues` - `boolean` - in file spec
 - `--synchronize-issues-on-add` - `boolean` - whether Backtrace will synchronize issues from 3rd party on adding them from link (only for ticket managing plugins), if updated
+  - `synchronizeIssuesOnAdd` - `boolean` - in file spec
 - `--connection` - `int` - connection ID to use by the integration, if updated
+  - `connectionId` - `int` - in file spec
 - `--from-file` - `string` - load integration spec from file
 - `--raw` - `boolean` - output raw JSON
 
@@ -1821,22 +1874,28 @@ Arguments provided by CLI will override the file spec, but they may not be requi
 
 Options:
 
-- `--name` - `string` - alert name, required
-- `--condition` - `object` - alert condition:
+- `--name` - `string` - alert name, required from CLI or file spec
+- `--condition` - `object` - alert condition, required from CLI or file spec:
   - `--condition.name` - `string` - can be one of:
     - `group`,
     - `trace`,
     - `usersPerFingerprint`,
-      - `--condition.timeFrame` - `int` - time frame in milliseconds, required
-      - `--condition.value` - `int` - number of users per fingerprint, required
+      - `--condition.timeFrame` - `int` - time frame in milliseconds, required from CLI or file spec
+      - `--condition.value` - `int` - number of users per fingerprint, required from CLI or file spec
     - `errorsPerFingerprint`
-      - `--condition.timeFrame` - `int` - time frame in milliseconds, required
-      - `--condition.value` - `int` - number of errors per fingerprint, required
-- `--frequency` - `int` - alert frequency in milliseconds, required
-- `--execution-delay` - `int` - alert execution delay in milliseconds, required
+      - `--condition.timeFrame` - `int` - time frame in milliseconds, required from CLI or file spec
+      - `--condition.value` - `int` - number of errors per fingerprint, required from CLI or file spec
+- `--frequency` - `int` - alert frequency in milliseconds, required from CLI or file spec
+- `--execution-delay` - `int` - alert execution delay in milliseconds, required from CLI or file spec
+  - `executionDelay` - `int` - in file spec
 - `--state` - `enabled|disabled|stopped` - alert state, optional
-- `--filters` - `filter` - alert filter, in the form of `<attribute>,<operator>,[value]`, optional
+- `--filter` - `filter` - alert filter, in the form of `<attribute>,<operator>,[value]`, optional
+  - `filters` - `filter[]` - in file spec, of which `filter` is an object with keys:
+    - `attribute` - `string` - attribute name,
+    - `filter[0]` - `string` - operator name,
+    - `filter[1]` - `any` - operator value
 - `--integration` - `int` - integration ID executed by alert, optional
+  - `integrations` - `int[]` - in file spec
 - `--from-file` - `string` - load alert spec from file
 - `--raw` - `boolean` - output raw JSON
 
@@ -1854,6 +1913,36 @@ morgue workflows alert create \
   --filter attr2,at-least,40 \
   --integration 20 \
   --integration 21 \
+```
+
+Example of file spec with above options:
+
+```
+morgue workflows alert create --project myProject --from-file spec.json
+```
+
+```json
+// spec.json
+{
+  "name": "myAlert",
+  "condition": {
+    "name": "usersPerFingerprint",
+    "timeFrame": 86400000,
+    "value": 10
+  },
+  "frequency": 60000,
+  "filters": [
+    {
+      "attribute": "attr1",
+      "op": ["equal", 50]
+    }, 
+    {
+      "attribute": "attr2",
+      "op": ["at-least", 40]
+    }
+  ],
+  "integrations": [20, 21]
+}
 ```
 
 #### Update an alert
@@ -1880,9 +1969,15 @@ Options:
       - `--condition.value` - `int` - number of errors per fingerprint, required
 - `--frequency` - `int` - alert frequency in milliseconds, if updated
 - `--execution-delay` - `int` - alert execution delay in milliseconds, if updated
+  - `executionDelay` - `int` - in file spec
 - `--state` - `enabled|disabled|stopped` - alert state, if updated
-- `--filters` - `filter` - alert filter, in the form of `<attribute>,<operator>,[value]`, if updated
+- `--filter` - `filter` - alert filter, in the form of `<attribute>,<operator>,[value]`, if updated
+  - `filters` - `filter[]` - in file spec, of which `filter` is an object with keys:
+    - `attribute` - `string` - attribute name,
+    - `filter[0]` - `string` - operator name,
+    - `filter[1]` - `any` - operator value
 - `--integration` - `int` - integration ID executed by alert, if updated
+  - `integrations` - `int[]` - in file spec
 - `--from-file` - `string` - load alert spec from file
 - `--raw` - `boolean` - output raw JSON
 

--- a/README.md
+++ b/README.md
@@ -1547,8 +1547,8 @@ morgue workflows alert [create | list | get | update | delete] <options>
 
 ### Managing connections
 
-Managing connections requires an universe to be specified.
-If it is not set via config or login, specify it by `--universe`.
+Managing connections requires a universe to be specified.
+If it is not set via config or login, specify it with `--universe`.
 
 #### List connections
 
@@ -1679,9 +1679,8 @@ morgue workflows connection delete 10
 
 ### Managing integrations
 
-Managing integrations requires an universe and a project to be specified.
-If the universe is not set via config or login, specify it by `--universe`.
-Specify the project using `--project`.
+Managing integrations requires both a universe and a project to be specified.
+If universe or project are not set via config or login, specify them with `--universe` and `--project`.
 
 #### List integrations
 
@@ -1715,7 +1714,7 @@ Example:
 morgue workflows integration get --project myProject 20
 ```
 
-#### Create a integration
+#### Create an integration
 
 ```
 morgue workflows integration create <options>
@@ -1777,14 +1776,14 @@ morgue workflows integration create --project myProject --from-file spec.json
 }
 ```
 
-#### Update a integration
+#### Update an integration
 
 ```
 morgue workflows integration update <options> <integration id>
 ```
 
 By using `--from-file`, you can load integration spec from file.
-Arguments provided by CLI will override the file spec, integrationy be not required anymore.
+Arguments provided by CLI will override the file spec, but they may not be required anymore.
 
 Options:
 
@@ -1809,7 +1808,7 @@ morgue workflows integration update \
   20
 ```
 
-#### Delete a integration
+#### Delete an integration
 
 ```
 morgue workflows integration delete [options] <integration id>
@@ -1827,9 +1826,8 @@ morgue workflows integration delete 20
 
 ### Managing alerts
 
-Managing alerts requires an universe and a project to be specified.
-If the universe is not set via config or login, specify it by `--universe`.
-Specify the project using `--project`.
+Managing alerts requires both a universe and a project to be specified.
+If universe or project are not set via config or login, specify them with `--universe` and `--project`.
 
 #### List alerts
 
@@ -1877,12 +1875,12 @@ Options:
 - `--name` - `string` - alert name, required from CLI or file spec
 - `--condition` - `object` - alert condition, required from CLI or file spec:
   - `--condition.name` - `string` - can be one of:
-    - `group`,
-    - `trace`,
-    - `usersPerFingerprint`,
+    - `group` - triggers when a new fingerprint (error group) is detected,
+    - `trace` - triggers when a new error is detected,
+    - `usersPerFingerprint` - triggers when number of users affected by a fingerprint is greater than `value` in `timeFrame`,
       - `--condition.timeFrame` - `int` - time frame in milliseconds, required from CLI or file spec
       - `--condition.value` - `int` - number of users per fingerprint, required from CLI or file spec
-    - `errorsPerFingerprint`
+    - `errorsPerFingerprint` - triggers when number of errors in a fingerprint is greater than `value` in `timeFrame`
       - `--condition.timeFrame` - `int` - time frame in milliseconds, required from CLI or file spec
       - `--condition.value` - `int` - number of errors per fingerprint, required from CLI or file spec
 - `--frequency` - `int` - alert frequency in milliseconds, required from CLI or file spec
@@ -1952,7 +1950,7 @@ morgue workflows alert update <options> <alert id>
 ```
 
 By using `--from-file`, you can load alert spec from file.
-Arguments provided by CLI will override the file spec, alerty be not required anymore.
+Arguments provided by CLI will override the file spec, but they may not be required anymore.
 
 Options:
 

--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -37,6 +37,7 @@ const alertsCli = require("../lib/alerts/cli");
 const timeCli = require('../lib/cli/time');
 const queryCli = require('../lib/cli/query');
 const { chalk, err, error_color, errx, success_color, warn } = require('../lib/cli/errors');
+const WorkflowsCli = require('../lib/workflows/cli.js');
 const bold = chalk.bold;
 const cyan = chalk.cyan;
 const grey = chalk.grey;
@@ -246,6 +247,7 @@ var commands = {
   "metrics-importer": metricsImporterCmd,
   stability: coronerStability,
   alerts: alertsCmd,
+  workflows: workflowsCmd,
 };
 
 process.stdout.on('error', function(){process.exit(0);});
@@ -7770,6 +7772,14 @@ async function alertsCmd(argv, config) {
   const cli = await alertsCli.alertsCliFromCoroner(coroner, argv, config);
   argv._.shift();
   await cli.routeMethod(argv);
+}
+
+async function workflowsCmd(argv, config) {
+  abortIfNotLoggedIn(config);
+  const coroner = coronerClientArgv(config, argv);
+  const cli = await WorkflowsCli.fromCoroner(coroner, argv, config);
+  argv._.shift();
+  await cli.routeMethod(argv)
 }
 
 function projectIdFromFlags(config, model, argv) {

--- a/lib/baseServiceClient.js
+++ b/lib/baseServiceClient.js
@@ -85,15 +85,7 @@ class BaseServiceClient {
         if (err) {
           reject(err);
         } else {
-          if (resp.statusCode >= 400) {
-            if (body && body.error && body.error.message) {
-              reject(`HTTP status ${resp.statusCode}: ${body.error.message}`);
-            } else {
-              reject(`HTTP status ${ resp.statusCode }`);
-            }
-          } else {
-            resolve(body);
-          }
+          this.handleResponse(resp, body).then(resolve).catch(reject);
         }
       });
     });
@@ -124,6 +116,20 @@ class BaseServiceClient {
       }
       qs.page_token = token;
       batch = await this.request({ method, path, body, qs });
+    }
+  }
+
+  async handleResponse(resp, body) {
+    if (resp.statusCode >= 400) {
+      if (body && body.error && body.error.message) {
+        throw new Error(
+          `HTTP status ${resp.statusCode}: ${body.error.message}`
+        );
+      } else {
+        throw new Error(`HTTP status ${resp.statusCode}`);
+      }
+    } else {
+      return body;
     }
   }
 }

--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -35,7 +35,7 @@ function validateAtMostOne(option, value) {
 }
 
 /*
- * validates that the specified option was specified at most once.
+ * validates that the specified option is an object
  */
 function validateObject(option, value) {
   if (!value || typeof value !== "object") {
@@ -63,9 +63,14 @@ function convertAtMostOne(option, value) {
   return value;
 }
 
+/**
+ * Asserts that `value` is an object.
+ *
+ * If `value` is falsy and `defaultValue` is specified, it will be used instead.
+ */
 function convertObject(option, value, defaultValue = undefined) {
   if (defaultValue !== undefined && !value) {
-    return defaultValue === true ? {} : defaultValue;
+    return defaultValue;
   }
 
   if (!validateObject(option, value)) {

--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -100,12 +100,12 @@ const FALSE_STRINGS = new Set([ 'no', 'false', 'off', '0' ]);
 
 function convertBool(name, value, defaultValue = undefined) {
   let v;
-  if (defaultValue != undefined) {
+  if (defaultValue !== undefined) {
     v = convertAtMostOne(name, value);
   } else {
     v = convertOne(name, value);
   }
-  if (v == undefined) {
+  if (v === undefined) {
     return defaultValue;
   }
   if (typeof v === 'boolean') {

--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -63,9 +63,9 @@ function convertAtMostOne(option, value) {
   return value;
 }
 
-function convertObject(option, value, allowEmpty = false) {
-  if (allowEmpty && !value) {
-    return {};
+function convertObject(option, value, defaultValue = undefined) {
+  if (defaultValue !== undefined && !value) {
+    return defaultValue === true ? {} : defaultValue;
   }
 
   if (!validateObject(option, value)) {

--- a/lib/cli/options.js
+++ b/lib/cli/options.js
@@ -35,6 +35,17 @@ function validateAtMostOne(option, value) {
 }
 
 /*
+ * validates that the specified option was specified at most once.
+ */
+function validateObject(option, value) {
+  if (!value || typeof value !== "object") {
+    err(`--${option} must be specified as an object, e.g. --${option}.prop`);
+    return false;
+  }
+  return true;
+}
+
+/*
  * Given an option name and value, convert to a single value.
  * Will exit the process with an informative error if the conversion fails.
  */
@@ -46,7 +57,18 @@ function convertOne(option, value) {
 }
 
 function convertAtMostOne(option, value) {
-    if (!validateAtMostOne(option, value)) {
+  if (!validateAtMostOne(option, value)) {
+    process.exit(1);
+  }
+  return value;
+}
+
+function convertObject(option, value, allowEmpty = false) {
+  if (allowEmpty && !value) {
+    return {};
+  }
+
+  if (!validateObject(option, value)) {
     process.exit(1);
   }
   return value;
@@ -101,8 +123,10 @@ function convertBool(name, value, defaultValue = undefined) {
 module.exports = {
   validateOne,
   validateAtMostOne,
+  validateObject,
   convertOne,
   convertAtMostOne,
   convertMany,
+  convertObject,
   convertBool,
 };

--- a/lib/cli/query.js
+++ b/lib/cli/query.js
@@ -90,6 +90,39 @@ function parseFilterFlags(filter) {
   return flags;
 }
 
+function parseFilter(input) {
+  let [attribute, op, value, flags] = input.split(",");
+  if (!attribute || !op) {
+    errx("Filter must be of form <column>,<operation>[,<value>].");
+  }
+
+  if (attribute == "_tx" && value && typeof value === "string") {
+    // Convert 0x hex values
+    var rr = value.split("x");
+    if (rr.length === 2) {
+      value = parseInt(rr[1], 16);
+    }
+  }
+
+  /* Some operators don't require an argument. */
+  if (!value) {
+    return {
+      attribute,
+      filter: [op],
+    };
+  } else if (!flags) {
+    return {
+      attribute,
+      filter: [op, value],
+    };
+  } else {
+    return {
+      attribute,
+      filter: [op, value, parseFilterFlags(input)],
+    };
+  }
+}
+
 function argvQueryPrefold(argv, implicitTimestampOps) {
   var query = {};
   var d_age = null;
@@ -128,34 +161,12 @@ function argvQueryPrefold(argv, implicitTimestampOps) {
       argv.filter = [argv.filter];
 
     for (i = 0; i < argv.filter.length; i++) {
-      var r = argv.filter[i];
-      var expr = [];
-
-      r = r.split(',');
-      if (r.length < 2) {
-        errx('Filter must be of form <column>,<operation>[,<value>].');
+      const { attribute, filter } = parseFilter(argv.filter[i]);
+      if (!query.filter[0][attribute]) {
+        query.filter[0][attribute] = [];
       }
 
-      if (r[0] == "_tx" && r.length == 3 && typeof r[2] === "string") {
-        var rr = r[2].split("x");
-        if (rr.length === 2) {
-          r = [r[0], r[1], parseInt(rr[1], 16)];
-        }
-      }
-
-      if (!query.filter[0][r[0]])
-        query.filter[0][r[0]] = [];
-
-      /* Some operators don't require an argument. */
-      if (r.length == 2)
-        expr = [r[1]];
-      else if (r.length == 3)
-        expr = [r[1], r[2]];
-      else if (r.length == 4)
-        expr = [r[1], r[2], parseFilterFlags(r)];
-
-
-      query.filter[0][r[0]].push(expr);
+      query.filter[0][attribute].push(filter);
     }
   }
 
@@ -408,6 +419,7 @@ function argvQuery(argv, implicitTimeOps=false, doFolds=false) {
 module.exports = {
   argvQuery,
   argvQueryFilterOnly,
+  parseFilter,
 };
 
 //-- vim:ts=2:et:sw=2

--- a/lib/workflows/alerts.js
+++ b/lib/workflows/alerts.js
@@ -91,7 +91,7 @@ class WorkflowsAlertsCli {
 }
 
 function printAlert(alert) {
-  console.log(alert.id);
+  console.log(`Alert ID=${alert.id}`);
   console.log(`  name=${alert.name} state=${alert.state}`);
 }
 

--- a/lib/workflows/alerts.js
+++ b/lib/workflows/alerts.js
@@ -1,0 +1,93 @@
+const { output, loadInit } = require("./utils");
+const cliOptions = require("../cli/options");
+const CreateAlert = require("./models/createAlert");
+const router = require("../cli/router");
+const UpdateAlert = require("./models/updateAlert");
+
+const HELP_MESSAGE = `
+Usage:
+
+morgue workflows alert [create | list | get | update | delete] <args>
+
+See the Morgue README for option documentation.
+`;
+
+class WorkflowsAlertsCli {
+  constructor(client, universe, project) {
+    this.client = client;
+    this.universe = universe;
+    this.project = project;
+  }
+
+  async routeMethod(argv) {
+    const routes = {
+      get: this.getAlert.bind(this),
+      list: this.getAlerts.bind(this),
+      create: this.createAlert.bind(this),
+      update: this.updateAlert.bind(this),
+      delete: this.deleteAlert.bind(this),
+    };
+
+    await router.route(routes, HELP_MESSAGE, argv);
+  }
+
+  async getAlert(argv) {
+    const id = cliOptions.convertAtMostOne("id", argv.id) || argv._[0];
+    const alert = await this.client.getAlert(this.universe, this.project, id);
+    output(alert, argv, printAlert);
+  }
+
+  async getAlerts(argv) {
+    const alerts = await this.client.getAlerts(this.universe, this.project);
+
+    alerts
+      .sort((i1, i2) => i1.watcherName.localeCompare(i2.watcherName))
+      .forEach((i) => output(i, argv, printAlert));
+  }
+
+  async createAlert(argv) {
+    const body = CreateAlert.fromArgv(argv, loadInit(argv));
+
+    const alert = await this.client.createAlert(
+      this.universe,
+      this.project,
+      body
+    );
+
+    output(alert, argv, printAlert);
+  }
+
+  async updateAlert(argv) {
+    const id = cliOptions.convertAtMostOne("id", argv.id) || argv._[0];
+
+    const body = UpdateAlert.fromArgv(argv, loadInit(argv));
+
+    const alert = await this.client.updateAlert(
+      this.universe,
+      this.project,
+      id,
+      body
+    );
+
+    output(alert, argv, printAlert);
+  }
+
+  async deleteAlert(argv) {
+    const id = cliOptions.convertAtMostOne("id", argv.id) || argv._[0];
+
+    const alert = await this.client.deleteAlert(
+      this.universe,
+      this.project,
+      id
+    );
+
+    output(alert, argv, printAlert);
+  }
+}
+
+function printAlert(alert) {
+  console.log(alert.id);
+  console.log(`  name=${alert.name} state=${alert.state}`);
+}
+
+module.exports = WorkflowsAlertsCli;

--- a/lib/workflows/alerts.js
+++ b/lib/workflows/alerts.js
@@ -3,6 +3,7 @@ const cliOptions = require("../cli/options");
 const CreateAlert = require("./models/createAlert");
 const router = require("../cli/router");
 const UpdateAlert = require("./models/updateAlert");
+const { errx } = require("../cli/errors");
 
 const HELP_MESSAGE = `
 Usage:
@@ -20,6 +21,10 @@ class WorkflowsAlertsCli {
   }
 
   async routeMethod(argv) {
+    if (!this.project) {
+      errx("--project is required");
+    }
+
     const routes = {
       get: this.getAlert.bind(this),
       list: this.getAlerts.bind(this),
@@ -32,7 +37,7 @@ class WorkflowsAlertsCli {
   }
 
   async getAlert(argv) {
-    const id = cliOptions.convertAtMostOne("id", argv.id) || argv._[0];
+    const id = cliOptions.convertOne("id", argv.id || argv._[0]);
     const alert = await this.client.getAlert(this.universe, this.project, id);
     output(alert, argv, printAlert);
   }
@@ -40,9 +45,11 @@ class WorkflowsAlertsCli {
   async getAlerts(argv) {
     const alerts = await this.client.getAlerts(this.universe, this.project);
 
-    alerts
-      .sort((i1, i2) => i1.watcherName.localeCompare(i2.watcherName))
-      .forEach((i) => output(i, argv, printAlert));
+    output(
+      alerts.sort((a1, a2) => a1.name.localeCompare(a2.name)),
+      argv,
+      printAlert
+    );
   }
 
   async createAlert(argv) {
@@ -58,8 +65,7 @@ class WorkflowsAlertsCli {
   }
 
   async updateAlert(argv) {
-    const id = cliOptions.convertAtMostOne("id", argv.id) || argv._[0];
-
+    const id = cliOptions.convertOne("id", argv.id || argv._[0]);
     const body = UpdateAlert.fromArgv(argv, loadInit(argv));
 
     const alert = await this.client.updateAlert(
@@ -73,8 +79,7 @@ class WorkflowsAlertsCli {
   }
 
   async deleteAlert(argv) {
-    const id = cliOptions.convertAtMostOne("id", argv.id) || argv._[0];
-
+    const id = cliOptions.convertOne("id", argv.id || argv._[0]);
     const alert = await this.client.deleteAlert(
       this.universe,
       this.project,

--- a/lib/workflows/cli.js
+++ b/lib/workflows/cli.js
@@ -9,7 +9,9 @@ const WorkflowsConnectionsCli = require("./connections");
 const HELP_MESSAGE = `
 Usage:
 
-morgue workflows integration <args>
+morgue workflows connection [create | list | get | update | delete] <options>
+morgue workflows integration [create | list | get | update | delete] <options>
+morgue workflows alert [create | list | get | update | delete] <options>
 
 See the Morgue README for option documentation.
 `;

--- a/lib/workflows/cli.js
+++ b/lib/workflows/cli.js
@@ -26,7 +26,7 @@ class WorkflowsCli {
 
   static async fromCoroner(coroner, argv, config) {
     let universe = cliOptions.convertAtMostOne("universe", argv.universe);
-    const project = cliOptions.convertOne("project", argv.project);
+    const project = cliOptions.convertAtMostOne("project", argv.project);
     /*
      * Currently the Rust service infrastructure doesn't support inferring
      * universe, so do it on our end if we can.

--- a/lib/workflows/cli.js
+++ b/lib/workflows/cli.js
@@ -1,0 +1,51 @@
+const cliOptions = require("../cli/options");
+const { errx } = require("../cli/errors");
+const WorkflowsClient = require("./client");
+const router = require("../cli/router");
+const WorkflowsIntegrationsCli = require("./integrations");
+
+const HELP_MESSAGE = `
+Usage:
+
+morgue workflows integration <args>
+
+See the Morgue README for option documentation.
+`;
+
+class WorkflowsCli {
+  constructor(client, universe, project) {
+    this.client = client;
+    this.universe = universe;
+    this.project = project;
+    this.integrations = new WorkflowsIntegrationsCli(client, universe, project);
+  }
+
+  static async fromCoroner(coroner, argv, config) {
+    let universe = cliOptions.convertAtMostOne("universe", argv.universe);
+    const project = cliOptions.convertOne("project", argv.project);
+    /*
+     * Currently the Rust service infrastructure doesn't support inferring
+     * universe, so do it on our end if we can.
+     */
+    if (!universe && config.config.universe) {
+      universe = config.config.universe.name;
+    }
+    if (!universe) {
+      errx(
+        "Unable to infer universe from config. Please provide --universe to select"
+      );
+    }
+    const client = await WorkflowsClient.fromCoroner(coroner);
+    return new WorkflowsCli(client, universe, project);
+  }
+
+  async routeMethod(args) {
+    const routes = {
+      integration: this.integrations.routeMethod.bind(this.integrations),
+    };
+
+    await router.route(routes, HELP_MESSAGE, args);
+  }
+}
+
+module.exports = WorkflowsCli;

--- a/lib/workflows/cli.js
+++ b/lib/workflows/cli.js
@@ -4,6 +4,7 @@ const WorkflowsClient = require("./client");
 const router = require("../cli/router");
 const WorkflowsIntegrationsCli = require("./integrations");
 const WorkflowsAlertsCli = require("./alerts");
+const WorkflowsConnectionsCli = require("./connections");
 
 const HELP_MESSAGE = `
 Usage:
@@ -20,6 +21,7 @@ class WorkflowsCli {
     this.project = project;
     this.integrations = new WorkflowsIntegrationsCli(client, universe, project);
     this.alerts = new WorkflowsAlertsCli(client, universe, project);
+    this.connections = new WorkflowsConnectionsCli(client, universe, project);
   }
 
   static async fromCoroner(coroner, argv, config) {
@@ -45,6 +47,7 @@ class WorkflowsCli {
     const routes = {
       integration: this.integrations.routeMethod.bind(this.integrations),
       alert: this.alerts.routeMethod.bind(this.alerts),
+      connection: this.connections.routeMethod.bind(this.connections),
     };
 
     await router.route(routes, HELP_MESSAGE, args);

--- a/lib/workflows/cli.js
+++ b/lib/workflows/cli.js
@@ -28,7 +28,7 @@ class WorkflowsCli {
     let universe = cliOptions.convertAtMostOne("universe", argv.universe);
     const project = cliOptions.convertAtMostOne("project", argv.project);
     /*
-     * Currently the Rust service infrastructure doesn't support inferring
+     * Currently the service infrastructure doesn't support inferring
      * universe, so do it on our end if we can.
      */
     if (!universe && config.config.universe) {

--- a/lib/workflows/cli.js
+++ b/lib/workflows/cli.js
@@ -3,6 +3,7 @@ const { errx } = require("../cli/errors");
 const WorkflowsClient = require("./client");
 const router = require("../cli/router");
 const WorkflowsIntegrationsCli = require("./integrations");
+const WorkflowsAlertsCli = require("./alerts");
 
 const HELP_MESSAGE = `
 Usage:
@@ -18,6 +19,7 @@ class WorkflowsCli {
     this.universe = universe;
     this.project = project;
     this.integrations = new WorkflowsIntegrationsCli(client, universe, project);
+    this.alerts = new WorkflowsAlertsCli(client, universe, project);
   }
 
   static async fromCoroner(coroner, argv, config) {
@@ -42,6 +44,7 @@ class WorkflowsCli {
   async routeMethod(args) {
     const routes = {
       integration: this.integrations.routeMethod.bind(this.integrations),
+      alert: this.alerts.routeMethod.bind(this.alerts),
     };
 
     await router.route(routes, HELP_MESSAGE, args);

--- a/lib/workflows/client.js
+++ b/lib/workflows/client.js
@@ -49,6 +49,43 @@ class WorkflowsClient extends BaseServiceClient {
     });
   }
 
+  getAlert(universe, project, idOrName) {
+    return this.request({
+      method: "GET",
+      path: `/universes/${universe}/projects/${project}/alerts/${idOrName}`,
+    });
+  }
+
+  getAlerts(universe, project) {
+    return this.request({
+      method: "GET",
+      path: `/universes/${universe}/projects/${project}/alerts`,
+    });
+  }
+
+  createAlert(universe, project, alert) {
+    return this.request({
+      method: "POST",
+      path: `/universes/${universe}/projects/${project}/alerts`,
+      body: alert,
+    });
+  }
+
+  updateAlert(universe, project, idOrName, alert) {
+    return this.request({
+      method: "PUT",
+      path: `/universes/${universe}/projects/${project}/alerts/${idOrName}`,
+      body: alert,
+    });
+  }
+
+  deleteAlert(universe, project, idOrName) {
+    return this.request({
+      method: "DELETE",
+      path: `/universes/${universe}/projects/${project}/alerts/${idOrName}`,
+    });
+  }
+
   async handleResponse(resp, body) {
     if (body.error) {
       err(body.error);

--- a/lib/workflows/client.js
+++ b/lib/workflows/client.js
@@ -12,10 +12,10 @@ class WorkflowsClient extends BaseServiceClient {
     );
   }
 
-  getIntegration(universe, project, idOrName) {
+  getIntegration(universe, project, id) {
     return this.request({
       method: "GET",
-      path: `/universes/${universe}/projects/${project}/integrations/${idOrName}`,
+      path: `/universes/${universe}/projects/${project}/integrations/${id}`,
     });
   }
 
@@ -34,25 +34,25 @@ class WorkflowsClient extends BaseServiceClient {
     });
   }
 
-  updateIntegration(universe, project, idOrName, integration) {
+  updateIntegration(universe, project, id, integration) {
     return this.request({
       method: "PUT",
-      path: `/universes/${universe}/projects/${project}/integrations/${idOrName}`,
+      path: `/universes/${universe}/projects/${project}/integrations/${id}`,
       body: integration,
     });
   }
 
-  deleteIntegration(universe, project, idOrName) {
+  deleteIntegration(universe, project, id) {
     return this.request({
       method: "DELETE",
-      path: `/universes/${universe}/projects/${project}/integrations/${idOrName}`,
+      path: `/universes/${universe}/projects/${project}/integrations/${id}`,
     });
   }
 
-  getAlert(universe, project, idOrName) {
+  getAlert(universe, project, id) {
     return this.request({
       method: "GET",
-      path: `/universes/${universe}/projects/${project}/alerts/${idOrName}`,
+      path: `/universes/${universe}/projects/${project}/alerts/${id}`,
     });
   }
 
@@ -71,18 +71,55 @@ class WorkflowsClient extends BaseServiceClient {
     });
   }
 
-  updateAlert(universe, project, idOrName, alert) {
+  updateAlert(universe, project, id, alert) {
     return this.request({
       method: "PUT",
-      path: `/universes/${universe}/projects/${project}/alerts/${idOrName}`,
+      path: `/universes/${universe}/projects/${project}/alerts/${id}`,
       body: alert,
     });
   }
 
-  deleteAlert(universe, project, idOrName) {
+  deleteAlert(universe, project, id) {
     return this.request({
       method: "DELETE",
-      path: `/universes/${universe}/projects/${project}/alerts/${idOrName}`,
+      path: `/universes/${universe}/projects/${project}/alerts/${id}`,
+    });
+  }
+
+  getConnection(universe, id) {
+    return this.request({
+      method: "GET",
+      path: `/universes/${universe}/connections/${id}`,
+    });
+  }
+
+  getConnections(universe) {
+    return this.request({
+      method: "GET",
+      path: `/universes/${universe}/connections`,
+    });
+  }
+
+  createConnection(universe, connection) {
+    return this.request({
+      method: "POST",
+      path: `/universes/${universe}/connections`,
+      body: connection,
+    });
+  }
+
+  updateConnection(universe, id, connection) {
+    return this.request({
+      method: "PUT",
+      path: `/universes/${universe}/connections/${id}`,
+      body: connection,
+    });
+  }
+
+  deleteConnection(universe, id) {
+    return this.request({
+      method: "DELETE",
+      path: `/universes/${universe}/connections/${id}`,
     });
   }
 

--- a/lib/workflows/client.js
+++ b/lib/workflows/client.js
@@ -1,7 +1,34 @@
 const { BaseServiceClient } = require("../baseServiceClient");
 const { err } = require("../cli/errors");
 
+const urlBuilder = (...parts) => {
+  return "/" + parts.filter((p) => p !== undefined).join("/");
+};
+
+const integrationsApiPath = (universe, project, id) => {
+  return urlBuilder(
+    "universes",
+    universe,
+    "projects",
+    project,
+    "integrations",
+    id
+  );
+};
+
+const alertsApiPath = (universe, project, id) => {
+  return urlBuilder("universes", universe, "projects", project, "alerts", id);
+};
+
+const connectionsApiPath = (universe, id) => {
+  return urlBuilder("universes", universe, "connections", id);
+};
+
 class WorkflowsClient extends BaseServiceClient {
+  constructor(url, coronerLocation, coronerToken, insecure = false) {
+    super(url, coronerLocation, coronerToken, insecure);
+  }
+
   static async fromCoroner(coroner) {
     const serviceUrl = await coroner.find_service("workflows");
     return new WorkflowsClient(
@@ -15,21 +42,21 @@ class WorkflowsClient extends BaseServiceClient {
   getIntegration(universe, project, id) {
     return this.request({
       method: "GET",
-      path: `/universes/${universe}/projects/${project}/integrations/${id}`,
+      path: integrationsApiPath(universe, project, id),
     });
   }
 
   getIntegrations(universe, project) {
     return this.request({
       method: "GET",
-      path: `/universes/${universe}/projects/${project}/integrations`,
+      path: integrationsApiPath(universe, project),
     });
   }
 
   createIntegration(universe, project, integration) {
     return this.request({
       method: "POST",
-      path: `/universes/${universe}/projects/${project}/integrations`,
+      path: integrationsApiPath(universe, project),
       body: integration,
     });
   }
@@ -37,7 +64,7 @@ class WorkflowsClient extends BaseServiceClient {
   updateIntegration(universe, project, id, integration) {
     return this.request({
       method: "PUT",
-      path: `/universes/${universe}/projects/${project}/integrations/${id}`,
+      path: integrationsApiPath(universe, project, id),
       body: integration,
     });
   }
@@ -45,28 +72,28 @@ class WorkflowsClient extends BaseServiceClient {
   deleteIntegration(universe, project, id) {
     return this.request({
       method: "DELETE",
-      path: `/universes/${universe}/projects/${project}/integrations/${id}`,
+      path: integrationsApiPath(universe, project, id),
     });
   }
 
   getAlert(universe, project, id) {
     return this.request({
       method: "GET",
-      path: `/universes/${universe}/projects/${project}/alerts/${id}`,
+      path: alertsApiPath(universe, project, id),
     });
   }
 
   getAlerts(universe, project) {
     return this.request({
       method: "GET",
-      path: `/universes/${universe}/projects/${project}/alerts`,
+      path: alertsApiPath(universe, project),
     });
   }
 
   createAlert(universe, project, alert) {
     return this.request({
       method: "POST",
-      path: `/universes/${universe}/projects/${project}/alerts`,
+      path: alertsApiPath(universe, project),
       body: alert,
     });
   }
@@ -74,7 +101,7 @@ class WorkflowsClient extends BaseServiceClient {
   updateAlert(universe, project, id, alert) {
     return this.request({
       method: "PUT",
-      path: `/universes/${universe}/projects/${project}/alerts/${id}`,
+      path: alertsApiPath(universe, project, id),
       body: alert,
     });
   }
@@ -82,28 +109,28 @@ class WorkflowsClient extends BaseServiceClient {
   deleteAlert(universe, project, id) {
     return this.request({
       method: "DELETE",
-      path: `/universes/${universe}/projects/${project}/alerts/${id}`,
+      path: alertsApiPath(universe, project, id),
     });
   }
 
   getConnection(universe, id) {
     return this.request({
       method: "GET",
-      path: `/universes/${universe}/connections/${id}`,
+      path: connectionsApiPath(universe, id),
     });
   }
 
   getConnections(universe) {
     return this.request({
       method: "GET",
-      path: `/universes/${universe}/connections`,
+      path: connectionsApiPath(universe),
     });
   }
 
   createConnection(universe, connection) {
     return this.request({
       method: "POST",
-      path: `/universes/${universe}/connections`,
+      path: connectionsApiPath(universe),
       body: connection,
     });
   }
@@ -111,7 +138,7 @@ class WorkflowsClient extends BaseServiceClient {
   updateConnection(universe, id, connection) {
     return this.request({
       method: "PUT",
-      path: `/universes/${universe}/connections/${id}`,
+      path: connectionsApiPath(universe, id),
       body: connection,
     });
   }
@@ -119,7 +146,7 @@ class WorkflowsClient extends BaseServiceClient {
   deleteConnection(universe, id) {
     return this.request({
       method: "DELETE",
-      path: `/universes/${universe}/connections/${id}`,
+      path: connectionsApiPath(universe, id),
     });
   }
 

--- a/lib/workflows/client.js
+++ b/lib/workflows/client.js
@@ -1,0 +1,68 @@
+const { BaseServiceClient } = require("../baseServiceClient");
+const { err } = require("../cli/errors");
+
+class WorkflowsClient extends BaseServiceClient {
+  static async fromCoroner(coroner) {
+    const serviceUrl = await coroner.find_service("workflows");
+    return new WorkflowsClient(
+      serviceUrl,
+      coroner.endpoint,
+      coroner.config.token,
+      coroner.insecure
+    );
+  }
+
+  getIntegration(universe, project, idOrName) {
+    return this.request({
+      method: "GET",
+      path: `/universes/${universe}/projects/${project}/integrations/${idOrName}`,
+    });
+  }
+
+  getIntegrations(universe, project) {
+    return this.request({
+      method: "GET",
+      path: `/universes/${universe}/projects/${project}/integrations`,
+    });
+  }
+
+  createIntegration(universe, project, integration) {
+    return this.request({
+      method: "POST",
+      path: `/universes/${universe}/projects/${project}/integrations`,
+      body: integration,
+    });
+  }
+
+  updateIntegration(universe, project, idOrName, integration) {
+    return this.request({
+      method: "PUT",
+      path: `/universes/${universe}/projects/${project}/integrations/${idOrName}`,
+      body: integration,
+    });
+  }
+
+  deleteIntegration(universe, project, idOrName) {
+    return this.request({
+      method: "DELETE",
+      path: `/universes/${universe}/projects/${project}/integrations/${idOrName}`,
+    });
+  }
+
+  async handleResponse(resp, body) {
+    if (body.error) {
+      err(body.error);
+      if (body.errorData) {
+        err(JSON.stringify(body.errorData, null, "\t"));
+      }
+
+      process.exit(1);
+    } else if (body.success) {
+      return body.body;
+    }
+
+    return super.handleResponse(resp, body);
+  }
+}
+
+module.exports = WorkflowsClient;

--- a/lib/workflows/connections.js
+++ b/lib/workflows/connections.js
@@ -1,8 +1,9 @@
-const { output, loadInit } = require("./utils");
+const { output, loadInit, getPluginId } = require("./utils");
 const cliOptions = require("../cli/options");
 const CreateConnection = require("./models/createConnection");
 const router = require("../cli/router");
 const UpdateConnection = require("./models/updateConnection");
+const { connectionOptions } = require("./plugins/plugins");
 
 const HELP_MESSAGE = `
 Usage:
@@ -47,22 +48,32 @@ class WorkflowsConnectionsCli {
   }
 
   async createConnection(argv) {
-    const body = CreateConnection.fromArgv(argv, loadInit(argv));
+    const init = loadInit(argv);
+    const pluginId = getPluginId(argv, init);
+    const optionsInitFn = connectionOptions(pluginId);
+
+    const body = CreateConnection.fromArgv(argv, init, optionsInitFn(pluginId));
     const connection = await this.client.createConnection(this.universe, body);
     output(connection, argv, printConnection);
   }
 
   async updateConnection(argv) {
     const id = cliOptions.convertOne("id", argv.id || argv._[0]);
-    const body = UpdateConnection.fromArgv(argv, loadInit(argv));
+    const connection = await this.client.getConnection(this.universe, id);
 
-    const connection = await this.client.updateConnection(
-      this.universe,
-      id,
-      body
+    const init = loadInit(argv);
+    const pluginId = connection.pluginId;
+    const optionsInitFn = connectionOptions(pluginId);
+
+    const body = UpdateConnection.fromArgv(
+      argv,
+      init,
+      optionsInitFn(argv, init)
     );
 
-    output(connection, argv, printConnection);
+    const updated = await this.client.updateConnection(this.universe, id, body);
+
+    output(updated, argv, printConnection);
   }
 
   async deleteConnection(argv) {

--- a/lib/workflows/connections.js
+++ b/lib/workflows/connections.js
@@ -1,0 +1,79 @@
+const { output, loadInit } = require("./utils");
+const cliOptions = require("../cli/options");
+const CreateConnection = require("./models/createConnection");
+const router = require("../cli/router");
+const UpdateConnection = require("./models/updateConnection");
+
+const HELP_MESSAGE = `
+Usage:
+
+morgue workflows connection [create | list | get | update | delete] <args>
+
+See the Morgue README for option documentation.
+`;
+
+class WorkflowsConnectionsCli {
+  constructor(client, universe) {
+    this.client = client;
+    this.universe = universe;
+  }
+
+  async routeMethod(argv) {
+    const routes = {
+      get: this.getConnection.bind(this),
+      list: this.getConnections.bind(this),
+      create: this.createConnection.bind(this),
+      update: this.updateConnection.bind(this),
+      delete: this.deleteConnection.bind(this),
+    };
+
+    await router.route(routes, HELP_MESSAGE, argv);
+  }
+
+  async getConnection(argv) {
+    const id = cliOptions.convertAtMostOne("id", argv.id) || argv._[0];
+    const connection = await this.client.getConnection(this.universe, id);
+    output(connection, argv, printConnection);
+  }
+
+  async getConnections(argv) {
+    const connections = await this.client.getConnections(this.universe);
+
+    connections
+      .sort((i1, i2) => i1.watcherName.localeCompare(i2.watcherName))
+      .forEach((i) => output(i, argv, printConnection));
+  }
+
+  async createConnection(argv) {
+    const body = CreateConnection.fromArgv(argv, loadInit(argv));
+    const connection = await this.client.createConnection(this.universe, body);
+    output(connection, argv, printConnection);
+  }
+
+  async updateConnection(argv) {
+    const id = cliOptions.convertAtMostOne("id", argv.id) || argv._[0];
+
+    const body = UpdateConnection.fromArgv(argv, loadInit(argv));
+
+    const connection = await this.client.updateConnection(
+      this.universe,
+      id,
+      body
+    );
+
+    output(connection, argv, printConnection);
+  }
+
+  async deleteConnection(argv) {
+    const id = cliOptions.convertAtMostOne("id", argv.id) || argv._[0];
+    const connection = await this.client.deleteConnection(this.universe, id);
+    output(connection, argv, printConnection);
+  }
+}
+
+function printConnection(connection) {
+  console.log(connection.id);
+  console.log(`  name=${connection.name} plugin=${connection.pluginId}`);
+}
+
+module.exports = WorkflowsConnectionsCli;

--- a/lib/workflows/connections.js
+++ b/lib/workflows/connections.js
@@ -31,7 +31,7 @@ class WorkflowsConnectionsCli {
   }
 
   async getConnection(argv) {
-    const id = cliOptions.convertAtMostOne("id", argv.id) || argv._[0];
+    const id = cliOptions.convertOne("id", argv.id || argv._[0]);
     const connection = await this.client.getConnection(this.universe, id);
     output(connection, argv, printConnection);
   }
@@ -39,9 +39,11 @@ class WorkflowsConnectionsCli {
   async getConnections(argv) {
     const connections = await this.client.getConnections(this.universe);
 
-    connections
-      .sort((i1, i2) => i1.watcherName.localeCompare(i2.watcherName))
-      .forEach((i) => output(i, argv, printConnection));
+    output(
+      connections.sort((c1, c2) => c1.name.localeCompare(c2.name)),
+      argv,
+      printConnection
+    );
   }
 
   async createConnection(argv) {
@@ -51,8 +53,7 @@ class WorkflowsConnectionsCli {
   }
 
   async updateConnection(argv) {
-    const id = cliOptions.convertAtMostOne("id", argv.id) || argv._[0];
-
+    const id = cliOptions.convertOne("id", argv.id || argv._[0]);
     const body = UpdateConnection.fromArgv(argv, loadInit(argv));
 
     const connection = await this.client.updateConnection(
@@ -65,7 +66,7 @@ class WorkflowsConnectionsCli {
   }
 
   async deleteConnection(argv) {
-    const id = cliOptions.convertAtMostOne("id", argv.id) || argv._[0];
+    const id = cliOptions.convertOne("id", argv.id || argv._[0]);
     const connection = await this.client.deleteConnection(this.universe, id);
     output(connection, argv, printConnection);
   }

--- a/lib/workflows/connections.js
+++ b/lib/workflows/connections.js
@@ -84,7 +84,7 @@ class WorkflowsConnectionsCli {
 }
 
 function printConnection(connection) {
-  console.log(connection.id);
+  console.log(`Connection ID=${connection.id}`);
   console.log(`  name=${connection.name} plugin=${connection.pluginId}`);
 }
 

--- a/lib/workflows/integrations.js
+++ b/lib/workflows/integrations.js
@@ -120,7 +120,7 @@ class WorkflowsIntegrationsCli {
 }
 
 function printIntegration(integration) {
-  console.log(integration.id);
+  console.log(`Integration ID=${integration.id}`);
   console.log(
     `  name=${integration.watcherName} plugin=${integration.pluginId} state=${integration.state}`
   );

--- a/lib/workflows/integrations.js
+++ b/lib/workflows/integrations.js
@@ -3,6 +3,7 @@ const cliOptions = require("../cli/options");
 const router = require("../cli/router");
 const UpdateIntegration = require("./models/updateIntegration");
 const { output, loadInit } = require("./utils");
+const { errx } = require("../cli/errors");
 
 const HELP_MESSAGE = `
 Usage:
@@ -20,6 +21,10 @@ class WorkflowsIntegrationsCli {
   }
 
   async routeMethod(argv) {
+    if (!this.project) {
+      errx("--project is required");
+    }
+
     const routes = {
       get: this.getIntegration.bind(this),
       list: this.getIntegrations.bind(this),
@@ -32,15 +37,11 @@ class WorkflowsIntegrationsCli {
   }
 
   async getIntegration(argv) {
-    const idOrName =
-      cliOptions.convertAtMostOne("id", argv.id) ||
-      cliOptions.convertAtMostOne("name", argv.name) ||
-      argv._[0];
-
+    const id = cliOptions.convertOne("id", argv.id || argv._[0]);
     const integration = await this.client.getIntegration(
       this.universe,
       this.project,
-      idOrName
+      id
     );
 
     output(integration, argv, printIntegration);
@@ -59,7 +60,6 @@ class WorkflowsIntegrationsCli {
 
   async createIntegration(argv) {
     const body = CreateIntegration.fromArgv(argv, loadInit(argv));
-
     const integration = await this.client.createIntegration(
       this.universe,
       this.project,
@@ -70,17 +70,13 @@ class WorkflowsIntegrationsCli {
   }
 
   async updateIntegration(argv) {
-    const idOrName =
-      cliOptions.convertAtMostOne("id", argv.id) ||
-      cliOptions.convertAtMostOne("name", argv.name) ||
-      argv._[0];
-
+    const id = cliOptions.convertOne("id", argv.id || argv._[0]);
     const body = UpdateIntegration.fromArgv(argv, loadInit(argv));
 
     const integration = await this.client.updateIntegration(
       this.universe,
       this.project,
-      idOrName,
+      id,
       body
     );
 
@@ -88,15 +84,11 @@ class WorkflowsIntegrationsCli {
   }
 
   async deleteIntegration(argv) {
-    const idOrName =
-      cliOptions.convertAtMostOne("id", argv.id) ||
-      cliOptions.convertAtMostOne("name", argv.name) ||
-      argv._[0];
-
+    const id = cliOptions.convertOne("id", argv.id || argv._[0]);
     const integration = await this.client.deleteIntegration(
       this.universe,
       this.project,
-      idOrName
+      id
     );
 
     output(integration, argv, printIntegration);

--- a/lib/workflows/integrations.js
+++ b/lib/workflows/integrations.js
@@ -2,8 +2,9 @@ const CreateIntegration = require("./models/createIntegration");
 const cliOptions = require("../cli/options");
 const router = require("../cli/router");
 const UpdateIntegration = require("./models/updateIntegration");
-const { output, loadInit } = require("./utils");
+const { output, loadInit, getPluginId } = require("./utils");
 const { errx } = require("../cli/errors");
+const { integrationOptions } = require("./plugins/plugins");
 
 const HELP_MESSAGE = `
 Usage:
@@ -59,7 +60,16 @@ class WorkflowsIntegrationsCli {
   }
 
   async createIntegration(argv) {
-    const body = CreateIntegration.fromArgv(argv, loadInit(argv));
+    const init = loadInit(argv);
+    const pluginId = getPluginId(argv, init);
+    const optionsInitFn = integrationOptions(pluginId);
+
+    const body = CreateIntegration.fromArgv(
+      argv,
+      init,
+      optionsInitFn(argv, init)
+    );
+
     const integration = await this.client.createIntegration(
       this.universe,
       this.project,
@@ -71,16 +81,30 @@ class WorkflowsIntegrationsCli {
 
   async updateIntegration(argv) {
     const id = cliOptions.convertOne("id", argv.id || argv._[0]);
-    const body = UpdateIntegration.fromArgv(argv, loadInit(argv));
+    const integration = await this.client.getIntegration(
+      this.universe,
+      this.project,
+      id
+    );
 
-    const integration = await this.client.updateIntegration(
+    const init = loadInit(argv);
+    const pluginId = integration.pluginId;
+    const optionsInitFn = integrationOptions(pluginId);
+
+    const body = UpdateIntegration.fromArgv(
+      argv,
+      init,
+      optionsInitFn(argv, init)
+    );
+
+    const updated = await this.client.updateIntegration(
       this.universe,
       this.project,
       id,
       body
     );
 
-    output(integration, argv, printIntegration);
+    output(updated, argv, printIntegration);
   }
 
   async deleteIntegration(argv) {

--- a/lib/workflows/integrations.js
+++ b/lib/workflows/integrations.js
@@ -1,0 +1,113 @@
+const CreateIntegration = require("./models/createIntegration");
+const cliOptions = require("../cli/options");
+const router = require("../cli/router");
+const UpdateIntegration = require("./models/updateIntegration");
+const { output, loadInit } = require("./utils");
+
+const HELP_MESSAGE = `
+Usage:
+
+morgue workflows integration [create | list | get | update | delete] <args>
+
+See the Morgue README for option documentation.
+`;
+
+class WorkflowsIntegrationsCli {
+  constructor(client, universe, project) {
+    this.client = client;
+    this.universe = universe;
+    this.project = project;
+  }
+
+  async routeMethod(argv) {
+    const routes = {
+      get: this.getIntegration.bind(this),
+      list: this.getIntegrations.bind(this),
+      create: this.createIntegration.bind(this),
+      update: this.updateIntegration.bind(this),
+      delete: this.deleteIntegration.bind(this),
+    };
+
+    await router.route(routes, HELP_MESSAGE, argv);
+  }
+
+  async getIntegration(argv) {
+    const idOrName =
+      cliOptions.convertAtMostOne("id", argv.id) ||
+      cliOptions.convertAtMostOne("name", argv.name) ||
+      argv._[0];
+
+    const integration = await this.client.getIntegration(
+      this.universe,
+      this.project,
+      idOrName
+    );
+
+    output(integration, argv, printIntegration);
+  }
+
+  async getIntegrations(argv) {
+    const integrations = await this.client.getIntegrations(
+      this.universe,
+      this.project
+    );
+
+    integrations
+      .sort((i1, i2) => i1.watcherName.localeCompare(i2.watcherName))
+      .forEach((i) => output(i, argv, printIntegration));
+  }
+
+  async createIntegration(argv) {
+    const body = CreateIntegration.fromArgv(argv, loadInit(argv));
+
+    const integration = await this.client.createIntegration(
+      this.universe,
+      this.project,
+      body
+    );
+
+    output(integration, argv, printIntegration);
+  }
+
+  async updateIntegration(argv) {
+    const idOrName =
+      cliOptions.convertAtMostOne("id", argv.id) ||
+      cliOptions.convertAtMostOne("name", argv.name) ||
+      argv._[0];
+
+    const body = UpdateIntegration.fromArgv(argv, loadInit(argv));
+
+    const integration = await this.client.updateIntegration(
+      this.universe,
+      this.project,
+      idOrName,
+      body
+    );
+
+    output(integration, argv, printIntegration);
+  }
+
+  async deleteIntegration(argv) {
+    const idOrName =
+      cliOptions.convertAtMostOne("id", argv.id) ||
+      cliOptions.convertAtMostOne("name", argv.name) ||
+      argv._[0];
+
+    const integration = await this.client.deleteIntegration(
+      this.universe,
+      this.project,
+      idOrName
+    );
+
+    output(integration, argv, printIntegration);
+  }
+}
+
+function printIntegration(integration) {
+  console.log(integration.id);
+  console.log(
+    `  name=${integration.watcherName} plugin=${integration.pluginId} state=${integration.state}`
+  );
+}
+
+module.exports = WorkflowsIntegrationsCli;

--- a/lib/workflows/models/createAlert.js
+++ b/lib/workflows/models/createAlert.js
@@ -12,6 +12,7 @@ class CreateAlert {
     threshold,
     frequency,
     integrations,
+    executionDelay,
   }) {
     this.name = name;
     this.condition = condition;
@@ -20,6 +21,7 @@ class CreateAlert {
     this.threshold = threshold;
     this.frequency = frequency;
     this.integrations = integrations;
+    this.executionDelay = executionDelay;
   }
 
   static fromArgv(argv, init) {
@@ -51,6 +53,10 @@ class CreateAlert {
             "integration",
             argv.integration ?? init.integrations,
             true
+          ),
+          executionDelay: cliOptions.convertAtMostOne(
+            "execution-delay",
+            argv["execution-delay"] || init.executionDelay
           ),
         })
       )

--- a/lib/workflows/models/createAlert.js
+++ b/lib/workflows/models/createAlert.js
@@ -1,0 +1,61 @@
+const cliOptions = require("../../cli/options");
+const assignDeep = require("assign-deep");
+const { parseFilter } = require("../../cli/query");
+const { skipNotDefinedKeys } = require("../utils");
+
+class CreateAlert {
+  constructor({
+    name,
+    condition,
+    state,
+    filters,
+    threshold,
+    frequency,
+    integrations,
+  }) {
+    this.name = name;
+    this.condition = condition;
+    this.state = state;
+    this.filters = filters;
+    this.threshold = threshold;
+    this.frequency = frequency;
+    this.integrations = integrations;
+  }
+
+  static fromArgv(argv, init) {
+    return new CreateAlert(
+      assignDeep(
+        init,
+        skipNotDefinedKeys({
+          name: cliOptions.convertOne("name", argv.name || init.name),
+          condition: cliOptions.convertObject(
+            "condition",
+            argv.condition || init.condition
+          ),
+          state: cliOptions.convertAtMostOne("state", argv.state || init.state),
+          filters: argv.filter
+            ? cliOptions
+                .convertMany("filter", argv.filter, true)
+                .map(parseFilter)
+                .map((filter) => ({ type: "attribute", ...filter }))
+            : cliOptions.convertMany("filter", init.filters, true),
+          threshold: cliOptions.convertAtMostOne(
+            "threshold",
+            argv.threshold ?? init.threshold
+          ),
+          frequency: cliOptions.convertOne(
+            "frequency",
+            argv.frequency ?? init.frequency
+          ),
+          integrations: cliOptions.convertMany(
+            "integration",
+            argv.integration ?? init.integrations,
+            true
+          ),
+        })
+      )
+    );
+  }
+}
+
+module.exports = CreateAlert;

--- a/lib/workflows/models/createConnection.js
+++ b/lib/workflows/models/createConnection.js
@@ -1,6 +1,6 @@
 const cliOptions = require("../../cli/options");
 const assignDeep = require("assign-deep");
-const { skipNotDefinedKeys } = require("../utils");
+const { skipNotDefinedKeys, getPluginId } = require("../utils");
 
 class CreateConnection {
   constructor({ pluginId, name, options }) {
@@ -15,10 +15,7 @@ class CreateConnection {
         init,
         skipNotDefinedKeys({
           name: cliOptions.convertOne("name", argv.name || init.name),
-          pluginId: cliOptions.convertOne(
-            "plugin",
-            argv.plugin || init.pluginId
-          ),
+          pluginId: getPluginId(argv, init),
           options,
         })
       )

--- a/lib/workflows/models/createConnection.js
+++ b/lib/workflows/models/createConnection.js
@@ -1,0 +1,32 @@
+const cliOptions = require("../../cli/options");
+const assignDeep = require("assign-deep");
+const { skipNotDefinedKeys } = require("../utils");
+
+class CreateConnection {
+  constructor({ pluginId, name, options }) {
+    this.pluginId = pluginId;
+    this.name = name;
+    this.options = options;
+  }
+
+  static fromArgv(argv, init) {
+    return new CreateConnection(
+      assignDeep(
+        init,
+        skipNotDefinedKeys({
+          name: cliOptions.convertOne("name", argv.name || init.name),
+          pluginId: cliOptions.convertOne(
+            "plugin",
+            argv.plugin || init.pluginId
+          ),
+          options: cliOptions.convertObject(
+            "options",
+            argv.options || init.options
+          ),
+        })
+      )
+    );
+  }
+}
+
+module.exports = CreateConnection;

--- a/lib/workflows/models/createConnection.js
+++ b/lib/workflows/models/createConnection.js
@@ -9,7 +9,7 @@ class CreateConnection {
     this.options = options;
   }
 
-  static fromArgv(argv, init) {
+  static fromArgv(argv, init, options) {
     return new CreateConnection(
       assignDeep(
         init,
@@ -19,10 +19,7 @@ class CreateConnection {
             "plugin",
             argv.plugin || init.pluginId
           ),
-          options: cliOptions.convertObject(
-            "options",
-            argv.options || init.options
-          ),
+          options,
         })
       )
     );

--- a/lib/workflows/models/createIntegration.js
+++ b/lib/workflows/models/createIntegration.js
@@ -21,7 +21,7 @@ class CreateIntegration {
     this.connectionId = connectionId;
   }
 
-  static fromArgv(argv, init) {
+  static fromArgv(argv, init, options) {
     return new CreateIntegration(
       assignDeep(
         init,
@@ -49,10 +49,7 @@ class CreateIntegration {
             "connection",
             argv.connection || init.connectionId
           ),
-          options: cliOptions.convertObject(
-            "options",
-            argv.options || init.options
-          ),
+          options,
         })
       )
     );

--- a/lib/workflows/models/createIntegration.js
+++ b/lib/workflows/models/createIntegration.js
@@ -37,15 +37,17 @@ class CreateIntegration {
           state: cliOptions.convertAtMostOne("state", argv.state || init.state),
           synchronizeIssues: cliOptions.convertBool(
             "synchronize-issues",
-            argv["synchronize-issues"] || init.synchronizeIssues
+            argv["synchronize-issues"] || init.synchronizeIssues,
+            null
           ),
           synchronizeIssuesOnAdd: cliOptions.convertBool(
             "synchronize-issues-on-add",
-            argv["synchronize-issues-on-add"] || init.synchronizeIssuesOnAdd
+            argv["synchronize-issues-on-add"] || init.synchronizeIssuesOnAdd,
+            null
           ),
           connectionId: cliOptions.convertAtMostOne(
             "connection",
-            argv.connectionId || init.connectionId
+            argv.connection || init.connectionId
           ),
           options: cliOptions.convertObject(
             "options",

--- a/lib/workflows/models/createIntegration.js
+++ b/lib/workflows/models/createIntegration.js
@@ -1,0 +1,60 @@
+const cliOptions = require("../../cli/options");
+const assignDeep = require("assign-deep");
+const { skipNotDefinedKeys } = require("../utils");
+
+class CreateIntegration {
+  constructor({
+    pluginId,
+    watcherName,
+    state,
+    synchronizeIssues,
+    synchronizeIssuesOnAdd,
+    options,
+    connectionId,
+  }) {
+    this.pluginId = pluginId;
+    this.watcherName = watcherName;
+    this.state = state;
+    this.synchronizeIssues = synchronizeIssues;
+    this.synchronizeIssuesOnAdd = synchronizeIssuesOnAdd;
+    this.options = options;
+    this.connectionId = connectionId;
+  }
+
+  static fromArgv(argv, init) {
+    return new CreateIntegration(
+      assignDeep(
+        init,
+        skipNotDefinedKeys({
+          pluginId: cliOptions.convertOne(
+            "plugin",
+            argv.plugin || init.pluginId
+          ),
+          watcherName: cliOptions.convertOne(
+            "name",
+            argv.name || init.watcherName
+          ),
+          state: cliOptions.convertAtMostOne("state", argv.state || init.state),
+          synchronizeIssues: cliOptions.convertBool(
+            "synchronize-issues",
+            argv["synchronize-issues"] || init.synchronizeIssues
+          ),
+          synchronizeIssuesOnAdd: cliOptions.convertBool(
+            "synchronize-issues-on-add",
+            argv["synchronize-issues-on-add"] || init.synchronizeIssuesOnAdd
+          ),
+          connectionId: cliOptions.convertAtMostOne(
+            "connection",
+            argv.connectionId || init.connectionId
+          ),
+          options: cliOptions.convertObject(
+            "options",
+            argv.options || init.options
+          ),
+        })
+      )
+    );
+  }
+}
+
+module.exports = CreateIntegration;

--- a/lib/workflows/models/createIntegration.js
+++ b/lib/workflows/models/createIntegration.js
@@ -1,6 +1,6 @@
 const cliOptions = require("../../cli/options");
 const assignDeep = require("assign-deep");
-const { skipNotDefinedKeys } = require("../utils");
+const { skipNotDefinedKeys, getPluginId } = require("../utils");
 
 class CreateIntegration {
   constructor({
@@ -26,10 +26,7 @@ class CreateIntegration {
       assignDeep(
         init,
         skipNotDefinedKeys({
-          pluginId: cliOptions.convertOne(
-            "plugin",
-            argv.plugin || init.pluginId
-          ),
+          pluginId: getPluginId(argv, init),
           watcherName: cliOptions.convertOne(
             "name",
             argv.name || init.watcherName

--- a/lib/workflows/models/updateAlert.js
+++ b/lib/workflows/models/updateAlert.js
@@ -1,0 +1,62 @@
+const cliOptions = require("../../cli/options");
+const assignDeep = require("assign-deep");
+const { parseFilter } = require("../../cli/query");
+const { skipNotDefinedKeys } = require("../utils");
+
+class UpdateAlert {
+  constructor({
+    name,
+    condition,
+    state,
+    filters,
+    threshold,
+    frequency,
+    integrations,
+  }) {
+    this.name = name;
+    this.condition = condition;
+    this.state = state;
+    this.filters = filters;
+    this.threshold = threshold;
+    this.frequency = frequency;
+    this.integrations = integrations;
+  }
+
+  static fromArgv(argv, init) {
+    return new UpdateAlert(
+      assignDeep(
+        init,
+        skipNotDefinedKeys({
+          name: cliOptions.convertAtMostOne("name", argv.name || init.name),
+          condition: cliOptions.convertObject(
+            "condition",
+            argv.condition || init.condition,
+            true
+          ),
+          state: cliOptions.convertAtMostOne("state", argv.state || init.state),
+          filters: argv.filter
+            ? cliOptions
+                .convertMany("filter", argv.filter, true)
+                .map(parseFilter)
+                .map((filter) => ({ type: "attribute", ...filter }))
+            : cliOptions.convertMany("filter", init.filters, true),
+          threshold: cliOptions.convertAtMostOne(
+            "threshold",
+            argv.threshold ?? init.threshold
+          ),
+          frequency: cliOptions.convertAtMostOne(
+            "frequency",
+            argv.frequency ?? init.frequency
+          ),
+          integrations: cliOptions.convertMany(
+            "integration",
+            argv.integration ?? init.integrations,
+            true
+          ),
+        })
+      )
+    );
+  }
+}
+
+module.exports = UpdateAlert;

--- a/lib/workflows/models/updateAlert.js
+++ b/lib/workflows/models/updateAlert.js
@@ -31,7 +31,7 @@ class UpdateAlert {
           condition: cliOptions.convertObject(
             "condition",
             argv.condition || init.condition,
-            true
+            {}
           ),
           state: cliOptions.convertAtMostOne("state", argv.state || init.state),
           filters: argv.filter

--- a/lib/workflows/models/updateAlert.js
+++ b/lib/workflows/models/updateAlert.js
@@ -12,6 +12,7 @@ class UpdateAlert {
     threshold,
     frequency,
     integrations,
+    executionDelay,
   }) {
     this.name = name;
     this.condition = condition;
@@ -20,6 +21,7 @@ class UpdateAlert {
     this.threshold = threshold;
     this.frequency = frequency;
     this.integrations = integrations;
+    this.executionDelay = executionDelay;
   }
 
   static fromArgv(argv, init) {
@@ -52,6 +54,10 @@ class UpdateAlert {
             "integration",
             argv.integration ?? init.integrations,
             true
+          ),
+          executionDelay: cliOptions.convertAtMostOne(
+            "execution-delay",
+            argv["execution-delay"] || init.executionDelay
           ),
         })
       )

--- a/lib/workflows/models/updateConnection.js
+++ b/lib/workflows/models/updateConnection.js
@@ -1,0 +1,28 @@
+const cliOptions = require("../../cli/options");
+const assignDeep = require("assign-deep");
+const { skipNotDefinedKeys } = require("../utils");
+
+class UpdateConnection {
+  constructor({ name, options }) {
+    this.name = name;
+    this.options = options;
+  }
+
+  static fromArgv(argv, init) {
+    return new UpdateConnection(
+      assignDeep(
+        init,
+        skipNotDefinedKeys({
+          name: cliOptions.convertAtMostOne("name", argv.name || init.name),
+          options: cliOptions.convertObject(
+            "options",
+            argv.options || init.options,
+            true
+          ),
+        })
+      )
+    );
+  }
+}
+
+module.exports = UpdateConnection;

--- a/lib/workflows/models/updateConnection.js
+++ b/lib/workflows/models/updateConnection.js
@@ -8,17 +8,13 @@ class UpdateConnection {
     this.options = options;
   }
 
-  static fromArgv(argv, init) {
+  static fromArgv(argv, init, options) {
     return new UpdateConnection(
       assignDeep(
         init,
         skipNotDefinedKeys({
           name: cliOptions.convertAtMostOne("name", argv.name || init.name),
-          options: cliOptions.convertObject(
-            "options",
-            argv.options || init.options,
-            true
-          ),
+          options,
         })
       )
     );

--- a/lib/workflows/models/updateIntegration.js
+++ b/lib/workflows/models/updateIntegration.js
@@ -11,13 +11,13 @@ class UpdateIntegration {
     connectionId,
   }) {
     this.state = state;
-    this.synchronizeIssues = synchronizeIssues || false;
-    this.synchronizeIssuesOnAdd = synchronizeIssuesOnAdd || false;
+    this.synchronizeIssues = synchronizeIssues;
+    this.synchronizeIssuesOnAdd = synchronizeIssuesOnAdd;
     this.options = options;
     this.connectionId = connectionId;
   }
 
-  static fromArgv(argv, init) {
+  static fromArgv(argv, init, options) {
     return new UpdateIntegration(
       assignDeep(
         init,
@@ -37,11 +37,7 @@ class UpdateIntegration {
             "connection",
             argv.connectionId || init.connectionId
           ),
-          options: cliOptions.convertObject(
-            "options",
-            argv.options || init.options,
-            true
-          ),
+          options,
         })
       )
     );

--- a/lib/workflows/models/updateIntegration.js
+++ b/lib/workflows/models/updateIntegration.js
@@ -25,11 +25,13 @@ class UpdateIntegration {
           state: cliOptions.convertAtMostOne("state", argv.state || init.state),
           synchronizeIssues: cliOptions.convertBool(
             "synchronize-issues",
-            argv["synchronize-issues"] || init.synchronizeIssues
+            argv["synchronize-issues"] || init.synchronizeIssues,
+            null
           ),
           synchronizeIssuesOnAdd: cliOptions.convertBool(
             "synchronize-issues-on-add",
-            argv["synchronize-issues-on-add"] || init.synchronizeIssuesOnAdd
+            argv["synchronize-issues-on-add"] || init.synchronizeIssuesOnAdd,
+            null
           ),
           connectionId: cliOptions.convertAtMostOne(
             "connection",

--- a/lib/workflows/models/updateIntegration.js
+++ b/lib/workflows/models/updateIntegration.js
@@ -1,0 +1,49 @@
+const cliOptions = require("../../cli/options");
+const assignDeep = require("assign-deep");
+const { skipNotDefinedKeys } = require("../utils");
+
+class UpdateIntegration {
+  constructor({
+    state,
+    synchronizeIssues,
+    synchronizeIssuesOnAdd,
+    options,
+    connectionId,
+  }) {
+    this.state = state;
+    this.synchronizeIssues = synchronizeIssues || false;
+    this.synchronizeIssuesOnAdd = synchronizeIssuesOnAdd || false;
+    this.options = options;
+    this.connectionId = connectionId;
+  }
+
+  static fromArgv(argv, init) {
+    return new UpdateIntegration(
+      assignDeep(
+        init,
+        skipNotDefinedKeys({
+          state: cliOptions.convertAtMostOne("state", argv.state || init.state),
+          synchronizeIssues: cliOptions.convertBool(
+            "synchronize-issues",
+            argv["synchronize-issues"] || init.synchronizeIssues
+          ),
+          synchronizeIssuesOnAdd: cliOptions.convertBool(
+            "synchronize-issues-on-add",
+            argv["synchronize-issues-on-add"] || init.synchronizeIssuesOnAdd
+          ),
+          connectionId: cliOptions.convertAtMostOne(
+            "connection",
+            argv.connectionId || init.connectionId
+          ),
+          options: cliOptions.convertObject(
+            "options",
+            argv.options || init.options,
+            true
+          ),
+        })
+      )
+    );
+  }
+}
+
+module.exports = UpdateIntegration;

--- a/lib/workflows/plugins/plugins.js
+++ b/lib/workflows/plugins/plugins.js
@@ -1,0 +1,21 @@
+const assignDeep = require("assign-deep");
+
+const PLUGINS = {
+  s3export: {
+    integration: require("./s3export/integrationOptions"),
+  },
+};
+
+const options = (key) => (pluginId) => {
+  const plugin = PLUGINS[pluginId];
+  const fn = (plugin && plugin[key]) || ((v) => v);
+  return (argv, init) =>
+    argv.options || init.options
+      ? fn(assignDeep({}, init.options || {}, argv.options || {}))
+      : undefined;
+};
+
+const integrationOptions = options("integration");
+const connectionOptions = options("connection");
+
+module.exports = { integrationOptions, connectionOptions };

--- a/lib/workflows/plugins/plugins.js
+++ b/lib/workflows/plugins/plugins.js
@@ -1,5 +1,8 @@
 const assignDeep = require("assign-deep");
 
+// These functions will be executed for create/update of integration/connection.
+// Use these if CLI arg parser doesn't parse the values correctly
+// (e.g. plugin requires an array, but parser returns one element for one arg and an array for two)
 const PLUGINS = {
   s3export: {
     integration: require("./s3export/integrationOptions"),

--- a/lib/workflows/plugins/s3export/integrationOptions.js
+++ b/lib/workflows/plugins/s3export/integrationOptions.js
@@ -1,0 +1,37 @@
+const cliOptions = require("../../../cli/options");
+const assignDeep = require("assign-deep");
+const { skipNotDefinedKeys } = require("../../utils");
+
+/**
+ * Schema:
+ *
+ * ```
+ * {
+ *   "bucketPath": string,
+ *   "credentials": {
+ *     "awsAccessKeyId": string,
+ *     "awsSecretAccessKey": string
+ *   },
+ *   "region": string,
+ *   "delimiter": string,
+ *   "header": boolean,
+ *   "attributeList": string[]
+ * }
+ * ```
+ */
+function integrationOptions(options) {
+  return assignDeep(
+    {},
+    options,
+    skipNotDefinedKeys({
+      attributeList: cliOptions.convertMany(
+        "options.attributeList",
+        options.attributeList,
+        true
+      ),
+      header: cliOptions.convertBool("options.header", options.header, null),
+    })
+  );
+}
+
+module.exports = integrationOptions;

--- a/lib/workflows/utils.js
+++ b/lib/workflows/utils.js
@@ -1,0 +1,25 @@
+const fs = require("fs");
+const cliOptions = require("../cli/options");
+
+function output(obj, argv, pretty) {
+  if (cliOptions.convertBool("raw", argv.raw, false)) {
+    console.log(JSON.stringify(obj, null, "  "));
+  } else {
+    pretty(obj);
+  }
+}
+
+function loadInit(argv) {
+  const filePath = cliOptions.convertAtMostOne("from-file", argv["from-file"]);
+  if (filePath) {
+    return JSON.parse(fs.readFileSync(filePath, "utf8"));
+  }
+
+  if (!process.stdin.isTTY) {
+    return JSON.parse(fs.readFileSync(process.stdin.fd, "utf8"));
+  }
+
+  return undefined;
+}
+
+module.exports = { output, loadInit };

--- a/lib/workflows/utils.js
+++ b/lib/workflows/utils.js
@@ -1,7 +1,12 @@
 const fs = require("fs");
 const cliOptions = require("../cli/options");
-const { errx } = require("../cli/errors");
 
+/**
+ * If `--raw` is specified, raw JSON is printed.
+ *
+ * Otherwise, `pretty` is executed on `obj`.
+ * If `obj` is an array, `pretty` is executed on each element separately.
+ */
 function output(obj, argv, pretty) {
   if (cliOptions.convertBool("raw", argv.raw, false)) {
     console.log(JSON.stringify(obj, null, "  "));
@@ -12,6 +17,9 @@ function output(obj, argv, pretty) {
   }
 }
 
+/**
+ * Loads initial config from file if `--from-file` is specified, or from stdin.
+ */
 function loadInit(argv) {
   const filePath = cliOptions.convertAtMostOne("from-file", argv["from-file"]);
   if (filePath) {
@@ -29,6 +37,9 @@ function getPluginId(argv, init) {
   return cliOptions.convertOne("plugin", argv.plugin || init.pluginId);
 }
 
+/**
+ * Returns objects without keys that have undefined or null value.
+ */
 function skipNotDefinedKeys(obj) {
   const result = {};
   for (const key in obj) {
@@ -41,25 +52,9 @@ function skipNotDefinedKeys(obj) {
   return result;
 }
 
-function errIfFalsy(value, message) {
-  if (!value) {
-    errx(message);
-  }
-}
-
-function undefinedIfEmpty(arr) {
-  if (Array.isArray(arr) && !arr.length) {
-    return undefined;
-  }
-
-  return arr;
-}
-
 module.exports = {
   output,
   loadInit,
   skipNotDefinedKeys,
-  errIfFalsy,
   getPluginId,
-  undefinedIfEmpty,
 };

--- a/lib/workflows/utils.js
+++ b/lib/workflows/utils.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const cliOptions = require("../cli/options");
+const { errx } = require("../cli/errors");
 
 function output(obj, argv, pretty) {
   if (cliOptions.convertBool("raw", argv.raw, false)) {
@@ -19,7 +20,25 @@ function loadInit(argv) {
     return JSON.parse(fs.readFileSync(process.stdin.fd, "utf8"));
   }
 
-  return undefined;
+  return {};
 }
 
-module.exports = { output, loadInit };
+function skipNotDefinedKeys(obj) {
+  const result = {};
+  for (const key in obj) {
+    if (obj[key] == undefined) {
+      continue;
+    }
+
+    result[key] = obj[key];
+  }
+  return result;
+}
+
+function errIfFalsy(value, message) {
+  if (!value) {
+    errx(message);
+  }
+}
+
+module.exports = { output, loadInit, skipNotDefinedKeys, errIfFalsy };

--- a/lib/workflows/utils.js
+++ b/lib/workflows/utils.js
@@ -34,7 +34,10 @@ function loadInit(argv) {
 }
 
 function getPluginId(argv, init) {
-  return cliOptions.convertOne("plugin", argv.plugin || init.pluginId);
+  return cliOptions.convertOne(
+    "plugin",
+    argv.plugin || argv.pluginId || init.pluginId
+  );
 }
 
 /**

--- a/lib/workflows/utils.js
+++ b/lib/workflows/utils.js
@@ -25,6 +25,10 @@ function loadInit(argv) {
   return {};
 }
 
+function getPluginId(argv, init) {
+  return cliOptions.convertOne("plugin", argv.plugin || init.pluginId);
+}
+
 function skipNotDefinedKeys(obj) {
   const result = {};
   for (const key in obj) {
@@ -43,4 +47,19 @@ function errIfFalsy(value, message) {
   }
 }
 
-module.exports = { output, loadInit, skipNotDefinedKeys, errIfFalsy };
+function undefinedIfEmpty(arr) {
+  if (Array.isArray(arr) && !arr.length) {
+    return undefined;
+  }
+
+  return arr;
+}
+
+module.exports = {
+  output,
+  loadInit,
+  skipNotDefinedKeys,
+  errIfFalsy,
+  getPluginId,
+  undefinedIfEmpty,
+};

--- a/lib/workflows/utils.js
+++ b/lib/workflows/utils.js
@@ -5,6 +5,8 @@ const { errx } = require("../cli/errors");
 function output(obj, argv, pretty) {
   if (cliOptions.convertBool("raw", argv.raw, false)) {
     console.log(JSON.stringify(obj, null, "  "));
+  } else if (Array.isArray(obj)) {
+    obj.forEach(pretty);
   } else {
     pretty(obj);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.24.3",
       "license": "GPL-2.0",
       "dependencies": {
+        "assign-deep": "^1.0.1",
         "axios": "^0.21.2",
         "babel-core": "^6.26.0",
         "backtrace-node": "^1.2.0",
@@ -541,6 +542,25 @@
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/assign-deep": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/assign-deep/-/assign-deep-1.0.1.tgz",
+      "integrity": "sha512-CSXAX79mibneEYfqLT5FEmkqR5WXF+xDRjgQQuVf6wSCXCYU8/vHttPidNar7wJ5BFmKAo8Wei0rCtzb+M/yeA==",
+      "dependencies": {
+        "assign-symbols": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/assign-deep/node_modules/assign-symbols": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-2.0.2.tgz",
+      "integrity": "sha512-9sBQUQZMKFKcO/C3Bo6Rx4CQany0R0UeVcefNGRRdW2vbmaMOhV1sbmlXcQLcD56juLXbSGTBm0GGuvmrAF8pA==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/assign-symbols": {
@@ -7891,6 +7911,21 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+    },
+    "assign-deep": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/assign-deep/-/assign-deep-1.0.1.tgz",
+      "integrity": "sha512-CSXAX79mibneEYfqLT5FEmkqR5WXF+xDRjgQQuVf6wSCXCYU8/vHttPidNar7wJ5BFmKAo8Wei0rCtzb+M/yeA==",
+      "requires": {
+        "assign-symbols": "^2.0.2"
+      },
+      "dependencies": {
+        "assign-symbols": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-2.0.2.tgz",
+          "integrity": "sha512-9sBQUQZMKFKcO/C3Bo6Rx4CQany0R0UeVcefNGRRdW2vbmaMOhV1sbmlXcQLcD56juLXbSGTBm0GGuvmrAF8pA=="
+        }
+      }
     },
     "assign-symbols": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/backtrace-labs/backtrace-morgue#readme",
   "dependencies": {
+    "assign-deep": "^1.0.1",
     "axios": "^0.21.2",
     "babel-core": "^6.26.0",
     "backtrace-node": "^1.2.0",


### PR DESCRIPTION
This PR adds a CLI that allows to manage workflows objects:

```
morgue workflows connection [create | list | get | update | delete] <options>
morgue workflows integration [create | list | get | update | delete] <options>
morgue workflows alert [create | list | get | update | delete] <options>
```

Inspired heavily by existing alerts CLI.

Jira task: BT-2130