### PR TITLE
Backtrace node update

### DIFF
--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -21,7 +21,7 @@ const mkdirp    = require('mkdirp');
 const promptLib = require('prompt');
 const path      = require('path');
 const table     = require('table').table;
-const bt        = require('backtrace-node');
+const bt        = require('@backtrace/node');
 const spawn     = require('child_process').spawn;
 const url       = require('url');
 const util      = require('util');
@@ -61,14 +61,15 @@ const configDir = process.env.MORGUE_CONFIG_DIR ||
 const configFile = path.join(configDir, "current.json");
 const BACKTRACE_ROLES = ['admin', 'member', 'guest']
 
-bt.initialize({
+const client = bt.BacktraceClient.initialize({
+  url: "https://submit.backtrace.io/backtrace/2cfca2efffd862c7ad7188be8db09d8697bd098a3561cd80a56fe5c4819f5d14/json",
   timeout: 5000,
-  endpoint: "https://backtrace.sp.backtrace.io:6098",
-  token: "2cfca2efffd862c7ad7188be8db09d8697bd098a3561cd80a56fe5c4819f5d14",
-  attributes: {
+  userAttributes: {
     version: packageJson.version,
   },
-  enableMetricsSupport: false
+  metrics: {
+    enable: false
+  }
 });
 
 function usage(str) {
@@ -6042,7 +6043,7 @@ function callstackPrint(cs) {
     callstack = JSON.parse(cs);
   } catch (error) {
     if (callstackError === false) {
-      bt.report(error);
+      client.send(error);
       callstackError = true;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.24.4",
       "license": "GPL-2.0",
       "dependencies": {
+        "@backtrace/node": "^0.3.0",
         "assign-deep": "^1.0.1",
         "axios": "^0.21.2",
         "babel-core": "^6.26.0",
-        "backtrace-node": "^1.2.0",
         "btoa": "^1.1.2",
         "chalk": "^4.1.2",
         "chrono-node": "^2.2.4",
@@ -44,6 +44,9 @@
         "eslint": "^7.12.1",
         "gulp": "^4.0.2",
         "gulp-babel": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -115,6 +118,37 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/@backtrace/node": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@backtrace/node/-/node-0.3.0.tgz",
+      "integrity": "sha512-ExyvtnMPKYhYZxLuSAUJfqoBIQqchGWhLmT6FLtiBIOG4XJtzBrco+9tElSPOJeay+v86lZlMVhLox8LZFrauA==",
+      "dependencies": {
+        "@backtrace/sdk-core": "^0.3.0",
+        "form-data": "^4.0.0",
+        "native-reg": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@backtrace/node/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@backtrace/sdk-core": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@backtrace/sdk-core/-/sdk-core-0.3.0.tgz",
+      "integrity": "sha512-rOiO70TIldmx2kUUhXs/KuZbo6UUEmUtwwI9CmKUsCBT41dENESDZTXWr+rrkfNYGYp3TEZVdm0dpUrcrQBKrA=="
     },
     "node_modules/@colors/colors": {
       "version": "1.5.0",
@@ -1325,19 +1359,6 @@
       },
       "engines": {
         "node": ">= 0.10"
-      }
-    },
-    "node_modules/backtrace-node": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/backtrace-node/-/backtrace-node-1.2.0.tgz",
-      "integrity": "sha512-vV2AehmEep9drtyqqlMKnOWxJ8Lj4w3OitbztVyGzA1VGSH9VQiueI2gsk0mpGbbZcGvelQvcuNj110PRG0GwA==",
-      "dependencies": {
-        "axios": "^0.21.1",
-        "form-data": "^2.3.3",
-        "json-stringify-safe": "^5.0.1",
-        "native-reg": "^0.3.5",
-        "source-scan": "~1.0.1",
-        "tslib": "^1.10.0"
       }
     },
     "node_modules/balanced-match": {
@@ -5175,12 +5196,12 @@
       }
     },
     "node_modules/native-reg": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/native-reg/-/native-reg-0.3.6.tgz",
-      "integrity": "sha512-ZkwWg509pUVXysRwZO1PQSB69BjP1/+wp6qMo1o6nkXp04ezNe27DV5Cxk5UgYlOECTDihezSom+oRjfRfSbJg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/native-reg/-/native-reg-1.1.1.tgz",
+      "integrity": "sha512-DmqwT6XC8MLwo8HaZey3bASf0aa/gHC7FAuKMjuf7fXa7FLXwz/khXGouKcmD1rXAfJME1XveKSM4+86wLkb1w==",
       "hasInstallScript": true,
       "dependencies": {
-        "node-gyp-build": "^4"
+        "node-gyp-build": "4"
       }
     },
     "node_modules/natural-compare": {
@@ -5196,9 +5217,9 @@
       "dev": true
     },
     "node_modules/node-gyp-build": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
+      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -6502,14 +6523,6 @@
       "deprecated": "See https://github.com/lydell/source-map-url#deprecated",
       "dev": true
     },
-    "node_modules/source-scan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/source-scan/-/source-scan-1.0.1.tgz",
-      "integrity": "sha1-C6n4wqk1b5UxplvrSLe7N2UE6Xs=",
-      "dependencies": {
-        "streamsink": "~1.2.0"
-      }
-    },
     "node_modules/sparkles": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
@@ -6977,11 +6990,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/tunnel-agent": {
       "version": "0.6.0",
@@ -7579,6 +7587,33 @@
           }
         }
       }
+    },
+    "@backtrace/node": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@backtrace/node/-/node-0.3.0.tgz",
+      "integrity": "sha512-ExyvtnMPKYhYZxLuSAUJfqoBIQqchGWhLmT6FLtiBIOG4XJtzBrco+9tElSPOJeay+v86lZlMVhLox8LZFrauA==",
+      "requires": {
+        "@backtrace/sdk-core": "^0.3.0",
+        "form-data": "^4.0.0",
+        "native-reg": "^1.1.1"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
+    "@backtrace/sdk-core": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@backtrace/sdk-core/-/sdk-core-0.3.0.tgz",
+      "integrity": "sha512-rOiO70TIldmx2kUUhXs/KuZbo6UUEmUtwwI9CmKUsCBT41dENESDZTXWr+rrkfNYGYp3TEZVdm0dpUrcrQBKrA=="
     },
     "@colors/colors": {
       "version": "1.5.0",
@@ -8648,19 +8683,6 @@
         "async-done": "^1.2.2",
         "async-settle": "^1.0.0",
         "now-and-later": "^2.0.0"
-      }
-    },
-    "backtrace-node": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/backtrace-node/-/backtrace-node-1.2.0.tgz",
-      "integrity": "sha512-vV2AehmEep9drtyqqlMKnOWxJ8Lj4w3OitbztVyGzA1VGSH9VQiueI2gsk0mpGbbZcGvelQvcuNj110PRG0GwA==",
-      "requires": {
-        "axios": "^0.21.1",
-        "form-data": "^2.3.3",
-        "json-stringify-safe": "^5.0.1",
-        "native-reg": "^0.3.5",
-        "source-scan": "~1.0.1",
-        "tslib": "^1.10.0"
       }
     },
     "balanced-match": {
@@ -11734,11 +11756,11 @@
       }
     },
     "native-reg": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/native-reg/-/native-reg-0.3.6.tgz",
-      "integrity": "sha512-ZkwWg509pUVXysRwZO1PQSB69BjP1/+wp6qMo1o6nkXp04ezNe27DV5Cxk5UgYlOECTDihezSom+oRjfRfSbJg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/native-reg/-/native-reg-1.1.1.tgz",
+      "integrity": "sha512-DmqwT6XC8MLwo8HaZey3bASf0aa/gHC7FAuKMjuf7fXa7FLXwz/khXGouKcmD1rXAfJME1XveKSM4+86wLkb1w==",
       "requires": {
-        "node-gyp-build": "^4"
+        "node-gyp-build": "4"
       }
     },
     "natural-compare": {
@@ -11754,9 +11776,9 @@
       "dev": true
     },
     "node-gyp-build": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg=="
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.0.tgz",
+      "integrity": "sha512-u6fs2AEUljNho3EYTJNBfImO5QTo/J/1Etd+NVdCj7qWKUSN/bSLkZwhDv7I+w/MSC6qJ4cknepkAYykDdK8og=="
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -12796,14 +12818,6 @@
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
     },
-    "source-scan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/source-scan/-/source-scan-1.0.1.tgz",
-      "integrity": "sha1-C6n4wqk1b5UxplvrSLe7N2UE6Xs=",
-      "requires": {
-        "streamsink": "~1.2.0"
-      }
-    },
     "sparkles": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.1.tgz",
@@ -13192,11 +13206,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
-    },
-    "tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "tunnel-agent": {
       "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "1.24.4",
   "description": "command line interface to the Backtrace object store",
   "main": "./lib/coroner.js",
+  "engines": {
+    "node": ">=14"
+  },
+  "engineStrict": true,
   "keywords": [
     "backtrace",
     "crashes",
@@ -20,10 +24,10 @@
   },
   "homepage": "https://github.com/backtrace-labs/backtrace-morgue#readme",
   "dependencies": {
+    "@backtrace/node": "^0.3.0",
     "assign-deep": "^1.0.1",
     "axios": "^0.21.2",
     "babel-core": "^6.26.0",
-    "backtrace-node": "^1.2.0",
     "btoa": "^1.1.2",
     "chalk": "^4.1.2",
     "chrono-node": "^2.2.4",


### PR DESCRIPTION
# Why

This diff changes the error reporting tool for backtrace-morgue. Starting now we are using @backtrace/node and we drop backtrace-node support.

refs: BT-2147