### PR TITLE
merge fingerprints using Workflows service if it's available

### DIFF
--- a/README.md
+++ b/README.md
@@ -779,10 +779,10 @@ independent again.
 When listing crashes, fingerprint;original can be used to get the original
 fingerprint from before the grouping process if wanted.
 
-**Note**: If the Workflows service is available in Coroner, the merge request 
-will be made to the service instead. First fingerprint is used as the source 
-fingerprint, from which all issue data is copied to the new merged fingerprint.
-
+**Note for on-premise deployments**: If the Workflows service is available in 
+Coroner, the merge request will be made to the service instead. The first 
+fingerprint is used as the source fingerprint from which all issue data is 
+copied to the new merged fingerprint.
 ### repair
 
 ```

--- a/README.md
+++ b/README.md
@@ -779,6 +779,10 @@ independent again.
 When listing crashes, fingerprint;original can be used to get the original
 fingerprint from before the grouping process if wanted.
 
+**Note**: If the Workflows service is available in Coroner, the merge request 
+will be made to the service instead. First fingerprint is used as the source 
+fingerprint, from which all issue data is copied to the new merged fingerprint.
+
 ### repair
 
 ```

--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -972,10 +972,14 @@ async function mergeFingerprints(argv, config) {
   const coroner = coronerClientArgv(config, argv);
   const isWorkflowsAvailable = await WorkflowsClient.isAvailable(coroner)
   if (isWorkflowsAvailable) {
-    console.log('Merging using the Workflows service')
+    if (argv.debug) {
+      console.log('Merging using the Workflows service')
+    }
     return _workflowsMerge(coroner, universe, project, fingerprints)
   } else {
-    console.log('Merging using Coroner directly')
+    if (argv.debug) {
+      console.log('Merging using Coroner directly')
+    }
     return _coronerMerge(coroner, universe, project, fingerprints, 'merge');
   }
 }

--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -38,6 +38,7 @@ const timeCli = require('../lib/cli/time');
 const queryCli = require('../lib/cli/query');
 const { chalk, err, error_color, errx, success_color, warn } = require('../lib/cli/errors');
 const WorkflowsCli = require('../lib/workflows/cli.js');
+const WorkflowsClient = require('../lib/workflows/client.js');
 const bold = chalk.bold;
 const cyan = chalk.cyan;
 const grey = chalk.grey;
@@ -243,8 +244,8 @@ var commands = {
   status: coronerStatus,
   user: coronerUser,
   users: coronerUsers,
-  merge: coronerMerge,
-  unmerge: coronerUnmerge,
+  merge: mergeFingerprints,
+  unmerge: unmergeFingerprints,
   "metrics-importer": metricsImporterCmd,
   stability: coronerStability,
   alerts: alertsCmd,
@@ -920,34 +921,21 @@ function dump_obj(o)
   console.log(util.inspect(o, {showHidden: false, depth: null}));
 }
 
-function _coronerMerge(argv, config, action) {
-  abortIfNotLoggedIn(config);
-  if (argv._.length === 0) {
-    userUsage();
-  }
-  const coroner = coronerClientArgv(config, argv);
-
-  if (argv._.length < 2) {
-    return usage("Missing project, universe arguments");
-  }
-  const p = coronerParams(argv, config);
-  let fingerprints = argv._;
-
-  fingerprints.splice(0,2);
+function _coronerMerge(coroner, universe, project, fingerprints, action) {
   const query = {
     actions: {
       fingerprint: [
-	{
-	  type: action,
-	  arguments: fingerprints
-	}
+        {
+          type: action,
+          arguments: fingerprints
+        }
       ]
     }
   };
 
   dump_obj(query);
 
-  coroner.query(p.universe, p.project, query, function(err, result) {
+  coroner.query(universe, project, query, function(err) {
     if (err) {
       errx(err.message);
     }
@@ -955,12 +943,60 @@ function _coronerMerge(argv, config, action) {
   });
 }
 
-function coronerMerge(argv, config) {
-  return _coronerMerge(argv, config, 'merge');
+async function _workflowsMerge(coroner, universe, project, fingerprints) {
+  const client = await WorkflowsClient.fromCoroner(coroner);
+  try {
+    await client.mergeFingerprints(universe, project, fingerprints)
+    console.log(success_color('Success.'));
+  } catch (err) {
+    errx(err.message);
+  }
 }
 
-function coronerUnmerge(argv, config) {
-  return _coronerMerge(argv, config, 'unmerge');
+async function mergeFingerprints(argv, config) {
+  abortIfNotLoggedIn(config);
+  if (argv._.length === 0) {
+    return userUsage();
+  }
+  
+  const { universe, project } = coronerParams(argv, config);
+  if (!universe || !project) {
+    return usage("Missing project, universe arguments");
+  }
+
+  const fingerprints = argv._.slice(2);
+  if (!fingerprints.length) {
+    return usage("At least one fingerprint must be specified")
+  }
+
+  const coroner = coronerClientArgv(config, argv);
+  const isWorkflowsAvailable = await WorkflowsClient.isAvailable(coroner)
+  if (isWorkflowsAvailable) {
+    console.log('Merging using the Workflows service')
+    return _workflowsMerge(coroner, universe, project, fingerprints)
+  } else {
+    console.log('Merging using Coroner directly')
+    return _coronerMerge(coroner, universe, project, fingerprints, 'merge');
+  }
+}
+
+function unmergeFingerprints(argv, config) {abortIfNotLoggedIn(config);
+  if (argv._.length === 0) {
+    return userUsage();
+  }
+  
+  const { universe, project} = coronerParams(argv, config);
+  if (!universe || !project) {
+    return usage("Missing project, universe arguments");
+  }
+
+  const fingerprints = argv._.slice(2);
+  if (!fingerprints.length) {
+    return usage("At least one fingerprint must be specified")
+  }
+
+  const coroner = coronerClientArgv(config, argv);
+  return _coronerMerge(coroner, universe, project, fingerprints, 'unmerge');
 }
 
 /*

--- a/lib/coroner.js
+++ b/lib/coroner.js
@@ -597,6 +597,22 @@ CoronerClient.prototype.delete_objects = function(universe, project, objects, pa
   this.post("/api/delete", { universe }, p, null, callback);
 };
 
+CoronerClient.prototype.get_config = async function (refresh) { 
+  if (!this._cached_config || refresh) {
+    const config = JSON.parse(await this.promise("get", "/api/config", {}));
+    this._cached_config = config
+    return config
+  }
+
+  return this._cached_config;  
+}
+
+CoronerClient.prototype.has_service = async function (name) {
+  const config = await this.get_config(name)
+  const serviceEntry = config.services.find(x => x.name === name);
+  return !!serviceEntry;
+}
+
 /*
  * Find a service from its name.
  */
@@ -609,8 +625,8 @@ CoronerClient.prototype.find_service = async function (name) {
    * get which currently only injects auth params if there's an object to
    * inject them into.
    */
-  const config = JSON.parse(await this.promise("get", "/api/config", {}));
-  const serviceEntry = config.services.filter(x => x.name === name)[0];
+  const config = await this.get_config(name)
+  const serviceEntry = config.services.find(x => x.name === name);
   if (!serviceEntry) {
     throw new Error(`No ${ name } service is configured`);
   }

--- a/lib/workflows/client.js
+++ b/lib/workflows/client.js
@@ -154,6 +154,28 @@ class WorkflowsClient extends BaseServiceClient {
     });
   }
 
+  mergeFingerprints(universe, project, fingerprints) {
+    return this.request({
+      method: "POST",
+      path: urlBuilder(
+        "issue",
+        "merge",
+        `?universe=${universe}&project=${project}`
+      ),
+      body: {
+        actions: {
+          fingerprint: [
+            {
+              type: "merge",
+              source: fingerprints[0],
+              arguments: fingerprints,
+            },
+          ],
+        },
+      },
+    });
+  }
+
   async handleResponse(resp, body) {
     if (body.error) {
       err(body.error);

--- a/lib/workflows/client.js
+++ b/lib/workflows/client.js
@@ -39,6 +39,10 @@ class WorkflowsClient extends BaseServiceClient {
     );
   }
 
+  static isAvailable(coroner) {
+    return coroner.has_service("workflows")
+  }
+
   getIntegration(universe, project, id) {
     return this.request({
       method: "GET",


### PR DESCRIPTION
This PR adds merging using Workflows service if it is available in /api/config.
If the service is available, but endpoint is empty, an exception will be thrown.

Unmerging fingerprints still goes through Coroner, as Workflows does not need to support that.
FIrst fingerprint is used as the source fingerprint when sending a request to Workflows.