### PR TITLE
morgue: use server side delete by query

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,20 +425,39 @@ sum(process.age): 29630010305216 sec
 
 ### delete
 
-Allows deleting objects.
+Allows deleting objects by query or by object identifiers.
 
 ```
-Usage: morgue delete <[universe/]project> <oid1> [... oidN]
+Usage: morgue delete <[universe/]project> [subset] <query> | <oid1> ... <oidN>
 ```
 
-Object IDs must be specified; they can be found in `morgue list` output.
-The object ID printed in the example above is `9d33`.
+An optional subset can be specified to indicate whether physical, indexed, or
+both are deleted. By default, this command (as of 2019-02-26) requests
+physical-only deletion, which retains only indexing.  The previous
+`--physical-only` argument is now a no-op.
 
-By default, this command (as of 2019-02-26) requests physical-only deletion,
-which retains only indexing.  The previous `--physical-only` argument is a
-no-op.  The following options affect this behavior:
-`--all`: Delete all related data, including indexing.
-`--crdb-only`: Only delete the indexed data; requires physically deleted objects.
+The following options affect this behavior:
+  * `--physical-only` (default): Deletes only the physical data.
+  * `--crdb-only`: Delete only the indexed data; requires physically deleted objects.
+  * `--all`: Delete all related data, including indexing.
+
+Either a query or a list of object identifiers must be passed.
+
+Queries follow the same format as the `morgue list` command.
+
+Object IDs can be obtained by using the `morgue list` output. The object ID
+printed in the previous example is `9d33`.
+
+Example: to delete all data, physical and indexed, in the blackhole project
+after 2023-11-14 22:13:20 UTC.
+```
+$ morgue delete blackhole --all --filter="timestamp,greater-than,1700000000"
+```
+
+Example: to delete physical data (default subset) for object with identifier 9d33.
+```
+$ morgue delete blackhole 9d33
+```
 
 ### project
 

--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -6752,7 +6752,7 @@ function coronerDelete(argv, config) {
   argvPushObjectRanges(o, argv);
 
   if (o.length === 0 && !(aq && aq.query)) {
-    errx('Must specify objects to be deleted.');
+    errx('Must specify either objects to be deleted or a query.');
   }
 
   if (argv.sync) {
@@ -6787,10 +6787,8 @@ function coronerDelete(argv, config) {
   }
 
   if (aq && aq.query) {
-    coroner.promise('query', p.universe, p.project, aq.query).then(function(r) {
-      unpackQueryObjects(o, r);
-      return delete_fn();
-    }).then(std_success_cb).catch(std_failure_cb);
+    coroner.promise('delete_by_query', p.universe, p.project, aq.query, params)
+      .then(std_success_cb).catch(std_failure_cb);
   } else {
     delete_fn().then(std_success_cb).catch(std_failure_cb);
   }

--- a/lib/coroner.js
+++ b/lib/coroner.js
@@ -597,6 +597,16 @@ CoronerClient.prototype.delete_objects = function(universe, project, objects, pa
   this.post("/api/delete", { universe }, p, null, callback);
 };
 
+CoronerClient.prototype.delete_by_query = function(universe, project, query, params, callback) {
+  var p = Object.assign({
+    universe: universe,
+    project: project,
+    query: query,
+  }, params);
+
+  this.post("/api/delete", { universe }, p, null, callback);
+};
+
 CoronerClient.prototype.get_config = async function (refresh) { 
   if (!this._cached_config || refresh) {
     const config = JSON.parse(await this.promise("get", "/api/config", {}));


### PR DESCRIPTION
The `morgue delete` command can take a query, rather than a list of objects, as input. This is implemented by first querying coronerd for the list of objects and then making separate requests to delete the individual objects in fixed sized batches.

As of Jan 2023, coronerd supports passing a query directly to the api/delete endpoint which can be more efficient than the back and forth described above. However, morgue was not updated to take advantage of this.

This commit fixes this and uses the `api/delete` endpoint directly with a filter-only query (no folds, etc). Updates the documentation to provide some example usage.

Internal ref: BT-2817