### PR TITLE
Add abort controller support for older node versions

### DIFF
--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -40,6 +40,7 @@ const queryCli = require('../lib/cli/query');
 const { chalk, err, error_color, errx, success_color, warn } = require('../lib/cli/errors');
 const WorkflowsCli = require('../lib/workflows/cli.js');
 const WorkflowsClient = require('../lib/workflows/client.js');
+const { createAbortController } = require("../lib/abortController");
 const bold = chalk.bold;
 const cyan = chalk.cyan;
 const grey = chalk.grey;
@@ -8032,7 +8033,7 @@ function main() {
   if (!command) return usage();
 
   // send reports from the previous session
-  const abortController = new AbortController();
+  const abortController = createAbortController()
   client.database.send(abortController.signal);
   promptLib.message = '';
   promptLib.delimiter = ':';

--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -8035,7 +8035,7 @@ function main() {
   if (!command) return usage();
 
   // send reports from the previous session
-  const abortController = createAbortController()
+  const abortController = new AbortController();
   client.database.send(abortController.signal);
   promptLib.message = '';
   promptLib.delimiter = ':';

--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -2,6 +2,9 @@
 
 'use strict';
 
+// setup abort controller
+require("../lib/abortController");
+
 const axios     = require('axios');
 const Callstack = require('../lib/callstack.js');
 const CoronerClient = require('../lib/coroner.js');
@@ -40,7 +43,6 @@ const queryCli = require('../lib/cli/query');
 const { chalk, err, error_color, errx, success_color, warn } = require('../lib/cli/errors');
 const WorkflowsCli = require('../lib/workflows/cli.js');
 const WorkflowsClient = require('../lib/workflows/client.js');
-const { createAbortController } = require("../lib/abortController");
 const bold = chalk.bold;
 const cyan = chalk.cyan;
 const grey = chalk.grey;

--- a/lib/abortController.js
+++ b/lib/abortController.js
@@ -124,7 +124,10 @@ class AbortController {
   }
 }
 
-const OriginalAbortController = AbortController;
+const OriginalAbortController = global.AbortController;
+if (!global.AbortController) {
+  global.AbortController = AbortController;
+}
 
 function createAbortController() {
   if (OriginalAbortController) {

--- a/lib/abortController.js
+++ b/lib/abortController.js
@@ -124,17 +124,6 @@ class AbortController {
   }
 }
 
-const OriginalAbortController = global.AbortController;
 if (!global.AbortController) {
   global.AbortController = AbortController;
 }
-
-function createAbortController() {
-  if (OriginalAbortController) {
-    return new OriginalAbortController();
-  } else {
-    return new AbortController();
-  }
-}
-
-module.exports.createAbortController = createAbortController;

--- a/lib/abortController.js
+++ b/lib/abortController.js
@@ -1,0 +1,137 @@
+class Emitter {
+  constructor() {
+    Object.defineProperty(this, "listeners", {
+      value: {},
+      writable: true,
+      configurable: true,
+    });
+  }
+  addEventListener(type, callback, options) {
+    if (!(type in this.listeners)) {
+      this.listeners[type] = [];
+    }
+    this.listeners[type].push({ callback, options });
+  }
+  removeEventListener(type, callback) {
+    if (!(type in this.listeners)) {
+      return;
+    }
+    const stack = this.listeners[type];
+    for (let i = 0, l = stack.length; i < l; i++) {
+      if (stack[i].callback === callback) {
+        stack.splice(i, 1);
+        return;
+      }
+    }
+  }
+  dispatchEvent(event) {
+    if (!(event.type in this.listeners)) {
+      return;
+    }
+    const stack = this.listeners[event.type];
+    const stackToCall = stack.slice();
+    for (let i = 0, l = stackToCall.length; i < l; i++) {
+      const listener = stackToCall[i];
+      try {
+        listener.callback.call(this, event);
+      } catch (e) {
+        Promise.resolve().then(() => {
+          throw e;
+        });
+      }
+      if (listener.options && listener.options.once) {
+        this.removeEventListener(event.type, listener.callback);
+      }
+    }
+    return !event.defaultPrevented;
+  }
+}
+
+class AbortSignal extends Emitter {
+  constructor() {
+    super();
+    // Some versions of babel does not transpile super() correctly for IE <= 10, if the parent
+    // constructor has failed to run, then "this.listeners" will still be undefined and then we call
+    // the parent constructor directly instead as a workaround. For general details, see babel bug:
+    // https://github.com/babel/babel/issues/3041
+    // This hack was added as a fix for the issue described here:
+    // https://github.com/Financial-Times/polyfill-library/pull/59#issuecomment-477558042
+    if (!this.listeners) {
+      Emitter.call(this);
+    }
+
+    // Compared to assignment, Object.defineProperty makes properties non-enumerable by default and
+    // we want Object.keys(new AbortController().signal) to be [] for compat with the native impl
+    Object.defineProperty(this, "aborted", {
+      value: false,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(this, "onabort", {
+      value: null,
+      writable: true,
+      configurable: true,
+    });
+    Object.defineProperty(this, "reason", {
+      value: undefined,
+      writable: true,
+      configurable: true,
+    });
+  }
+  toString() {
+    return "[object AbortSignal]";
+  }
+  dispatchEvent(event) {
+    if (event.type === "abort") {
+      this.aborted = true;
+      if (typeof this.onabort === "function") {
+        this.onabort.call(this, event);
+      }
+    }
+
+    super.dispatchEvent(event);
+  }
+}
+
+class AbortController {
+  constructor() {
+    // Compared to assignment, Object.defineProperty makes properties non-enumerable by default and
+    // we want Object.keys(new AbortController()) to be [] for compat with the native impl
+    Object.defineProperty(this, "signal", {
+      value: new AbortSignal(),
+      writable: true,
+      configurable: true,
+    });
+  }
+  abort(reason) {
+    let event = {
+      type: "abort",
+      bubbles: false,
+      cancelable: false,
+    };
+
+    let signalReason = reason;
+    if (signalReason === undefined) {
+      signalReason = new Error("This operation was aborted");
+      signalReason.name = "AbortError";
+    }
+    this.signal.reason = signalReason;
+
+    this.signal.dispatchEvent(event);
+  }
+  toString() {
+    return "[object AbortController]";
+  }
+}
+
+const OriginalAbortController = AbortController;
+
+function createAbortController() {
+  if (OriginalAbortController) {
+    return new OriginalAbortController();
+  } else {
+    return new AbortController();
+  }
+}
+
+module.exports.createAbortController = createAbortController;


### PR DESCRIPTION
# Why

This pull request adds support for the abort controller for node versions that don't support it. The abort controller is compatible with the abort controller required by the javascript SDK