### PR TITLE
morgue/sampling: adds last transacted object id to sampling status output

### DIFF
--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -3887,8 +3887,10 @@ function samplingStatusProject(argv, config, universe, project) {
         next = sprintf("after %s", timeCli.secondsToTimespec(next_time - now));
       }
     }
-    console.log(sprintf("    \"%s\": %d objects, last accept %s, next %s",
-      group.id ? group.id : "unknown", group.count, last.toString(), next));
+    console.log(sprintf("    \"%s\": %d objects, last accept _tx=%s on %s, next %s",
+      group.id ? group.id : "unknown", group.count,
+      group.last_accept_txid ? group.last_accept_txid.toString(16) : "unknown",
+      last.toString(), next));
   }
 }
 


### PR DESCRIPTION
In coronerd 1.62.50 and later, the status for a sampling group will contain the last transcated identifier that was accepted by that sampling group. Having the txid can aid in tracking down objects that were accepted by a particular sampling group but were then reprocessed and moved into a different group.

This commit adds the last accepted txid to the output in `samplingStatusProject` falling back to "unk" if the txid is not available.

Internal ref BT-3250