### PR TITLE
morgue/view: search for a view using the "%dashboard%" prefix

### DIFF
--- a/bin/morgue.js
+++ b/bin/morgue.js
@@ -4936,9 +4936,16 @@ function viewSetupFn(config, argv, opts, subcmd) {
   }
 
   if (subcmd !== 'create') {
+    // First search for a view by its query name.
     opts.state.query = opts.state.model.query.find((query) => 
       query.fields.name === opts.params.attrname
     );
+    // If not found, search for a view using the dashboard query name.
+    if (!opts.state.query) {
+      opts.state.query = opts.state.model.query.find((query) =>
+        query.fields.name === "%dashboard% " + opts.params.attrname
+      );
+    }
     if (!opts.state.query)
       return viewUsageFn("View not found.");
     opts.state.attr_key = {


### PR DESCRIPTION
The names of views created in the Backtrace dashboard are prefixed with "%dashboard%". To hide this internal detail and to make the command "morgue view delete" more convenient to use, automatically search for a view including the "%dashboard%" prefix if a view cannot be found with that name.

Addresses a problem reported where a "morgue view delete" command would return "Error: View not found." unexpectedly.

Internal Ref BT-5397